### PR TITLE
PAN-3642

### DIFF
--- a/src/cli/commands/specialists/done.ts
+++ b/src/cli/commands/specialists/done.ts
@@ -36,6 +36,19 @@ interface DoneOptions {
   uatNotes?: string;
 }
 
+// PAN-3642: this advisory deadline covers the PR comment, a stopped Claude
+// agent's summary-resume path, and all four same-key supervisor attempts plus
+// their retry sleeps. The previous 30s deadline expired during a valid retry
+// sequence and killed the specialist process before delivery could settle.
+export const FEEDBACK_DELIVERY_TIMEOUT_MS = 120_000;
+
+class FeedbackDeliveryTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`feedback delivery timed out after ${timeoutMs}ms`);
+    this.name = 'FeedbackDeliveryTimeoutError';
+  }
+}
+
 export async function doneCommand(
   specialist: string,
   issueId: string,
@@ -275,8 +288,8 @@ export async function doneCommand(
     // done` is run from inside the review agent's own session, so a hung delivery
     // leaves that agent waiting on a never-returning command and the issue stalls
     // in-review. Bound the whole step in wall-clock time so the CLI always exits;
-    // a missed comment/message is recovered by the deacon feedback janitor.
-    const FEEDBACK_DELIVERY_TIMEOUT_MS = 30_000;
+    // if that outer deadline is exhausted, persist a retryable stuck state before
+    // the specialist process exits instead of relying on an invisible warning.
     try {
       const { deliverReviewVerdictFeedback } = await import('../../../lib/cloister/review-verdict-feedback.js');
       const delivery = Effect.runPromise(deliverReviewVerdictFeedback({
@@ -289,7 +302,7 @@ export async function doneCommand(
       let timer: ReturnType<typeof setTimeout> | undefined;
       const timeout = new Promise<never>((_, reject) => {
         timer = setTimeout(
-          () => reject(new Error(`feedback delivery timed out after ${FEEDBACK_DELIVERY_TIMEOUT_MS}ms`)),
+          () => reject(new FeedbackDeliveryTimeoutError(FEEDBACK_DELIVERY_TIMEOUT_MS)),
           FEEDBACK_DELIVERY_TIMEOUT_MS,
         );
       });
@@ -300,6 +313,19 @@ export async function doneCommand(
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      if (err instanceof FeedbackDeliveryTimeoutError) {
+        const { surfaceIssueFeedbackNeedsYou } = await import('../../../lib/cloister/feedback-target.js');
+        await surfaceIssueFeedbackNeedsYou(
+          normalizedIssueId,
+          `Review feedback delivery exceeded the ${err.timeoutMs}ms advisory deadline before the keyed retry contract settled; retry remains required.`,
+          {
+            specialist: 'review-agent',
+            retryable: true,
+            source: 'specialists-done-timeout',
+            ...(options.runId ? { runId: options.runId } : {}),
+          },
+        );
+      }
       console.warn(chalk.yellow(`Could not deliver review feedback: ${message}`));
     }
   }

--- a/tests/cli/commands/specialists/done.test.ts
+++ b/tests/cli/commands/specialists/done.test.ts
@@ -13,6 +13,7 @@ const {
   mockFlushJournalWrites,
   mockReadVerdictFallback,
   mockVerdictFallbackPath,
+  mockSurfaceIssueFeedbackNeedsYou,
 } = vi.hoisted(() => ({
   mockSetReviewStatus: vi.fn(),
   mockGetReviewStatus: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mockFlushJournalWrites: vi.fn(),
   mockReadVerdictFallback: vi.fn(),
   mockVerdictFallbackPath: vi.fn(),
+  mockSurfaceIssueFeedbackNeedsYou: vi.fn(),
 }));
 
 vi.mock('../../../../src/lib/review-status.js', async (importOriginal) => {
@@ -38,6 +40,10 @@ vi.mock('../../../../src/lib/review-status.js', async (importOriginal) => {
 
 vi.mock('../../../../src/lib/cloister/review-verdict-feedback.js', () => ({
   deliverReviewVerdictFeedback: mockDeliverReviewVerdictFeedback,
+}));
+
+vi.mock('../../../../src/lib/cloister/feedback-target.js', () => ({
+  surfaceIssueFeedbackNeedsYou: mockSurfaceIssueFeedbackNeedsYou,
 }));
 
 vi.mock('../../../../src/lib/overdeck/review-status-record-sync.js', () => ({
@@ -234,22 +240,76 @@ describe('specialists done command', () => {
     });
   });
 
-  it('PAN-2524: persists the verdict before a hanging feedback delivery times out', async () => {
+  it('PAN-3642: allows summary resume plus all same-key retry stages to settle', async () => {
     vi.useFakeTimers();
-    mockDeliverReviewVerdictFeedback.mockReturnValue(Effect.never);
+    const stages: string[] = [];
+    const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+    mockDeliverReviewVerdictFeedback.mockReturnValue(Effect.promise(async () => {
+      await delay(5_000);
+      stages.push('summary-resumed');
+      for (let attempt = 1; attempt <= 3; attempt += 1) {
+        await delay(12_000);
+        stages.push(`ambiguous-${attempt}`);
+        await delay(2_000);
+      }
+      await delay(12_000);
+      stages.push('delivered');
+      return {
+        feedbackPath: '/workspace/.pan/feedback/001-review-agent-changes-requested.md',
+        prCommentPosted: true,
+        agentMessageSent: true,
+      };
+    }));
     const { doneCommand } = await import('../../../../src/cli/commands/specialists/done.js');
 
     const completion = doneCommand('review', 'pan-1059', {
       status: 'blocked',
+      notes: 'deliver after compaction',
+      runId: 'agent-pan-1059-review-abcdef12',
+    });
+    await vi.advanceTimersByTimeAsync(59_000);
+
+    await expect(completion).resolves.toBeUndefined();
+    expect(stages).toEqual([
+      'summary-resumed',
+      'ambiguous-1',
+      'ambiguous-2',
+      'ambiguous-3',
+      'delivered',
+    ]);
+    expect(mockSurfaceIssueFeedbackNeedsYou).not.toHaveBeenCalled();
+  });
+
+  it('PAN-2524/PAN-3642: persists the verdict and a retryable stuck state on outer timeout', async () => {
+    vi.useFakeTimers();
+    mockDeliverReviewVerdictFeedback.mockReturnValue(Effect.never);
+    const {
+      doneCommand,
+      FEEDBACK_DELIVERY_TIMEOUT_MS,
+    } = await import('../../../../src/cli/commands/specialists/done.js');
+
+    const completion = doneCommand('review', 'pan-1059', {
+      status: 'blocked',
       notes: 'durable first',
+      runId: 'agent-pan-1059-review-abcdef12',
     });
     expect(mockSetReviewStatus).toHaveBeenCalledWith('PAN-1059', {
       reviewStatus: 'blocked',
       reviewNotes: 'durable first',
     });
 
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(FEEDBACK_DELIVERY_TIMEOUT_MS);
     await expect(completion).resolves.toBeUndefined();
+    expect(mockSurfaceIssueFeedbackNeedsYou).toHaveBeenCalledWith(
+      'PAN-1059',
+      expect.stringContaining('retry remains required'),
+      {
+        specialist: 'review-agent',
+        retryable: true,
+        source: 'specialists-done-timeout',
+        runId: 'agent-pan-1059-review-abcdef12',
+      },
+    );
   });
 
   it('forces a successful CLI exit after durable completion', async () => {


### PR DESCRIPTION
**Issue:** #3642


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review feedback delivery now has a 120-second timeout.
  * When delivery times out, the system preserves the blocked verdict and displays a retryable issue with relevant specialist and run details.
  * Resumable feedback and retry stages can complete without incorrectly showing a recovery issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->