### PR TITLE
fix: include pan-gauntlet-loop in synced skills fixture

### DIFF
--- a/tests/fixtures/synced-skills.txt
+++ b/tests/fixtures/synced-skills.txt
@@ -43,6 +43,7 @@ pan-done
 pan-down
 pan-fly
 pan-flywheel
+pan-gauntlet-loop
 pan-handoff
 pan-help
 pan-hygiene


### PR DESCRIPTION
Closes #3664.\n\nRegenerates the canonical synced-skills fixture through the documented UPDATE_FIXTURES workflow. The resulting diff adds only pan-gauntlet-loop.\n\nTest: npx vitest run tests/fixtures/synced-skills.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated synced skills test fixtures to include the `pan-gauntlet-loop` skill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->