### PR TITLE
PAN-3713

### DIFF
--- a/src/cli/commands/swarm.ts
+++ b/src/cli/commands/swarm.ts
@@ -35,6 +35,7 @@ import { listSessionNamesSync } from '../../lib/tmux.js';
 import { removeAgent } from '../../lib/agents/removal.js';
 import { acknowledgeRecoveryTrip } from '../../lib/cloister/recovery-trip.js';
 import { resolveSlotWorkspaceWorktreesSync, type SlotWorkspaceWorktrees } from '../../lib/project-repos.js';
+import { isRegisteredWorktree } from '../../lib/cloister/deacon-swarm-gc.js';
 
 const execAsync = promisify(exec);
 
@@ -475,6 +476,29 @@ export async function swarmResetCommand(
   for (const slot of stalePolyrepoSlots) {
     for (const worktree of slot.nested) {
       try {
+        // PAN-3713: a branch already deleted by an earlier (partial) cleanup
+        // pass has nothing left to preserve — `git rev-list` on a missing ref
+        // would throw and wedge every re-run. It is durable when origin still
+        // has it; when origin lacks it too, the only way it vanished is this
+        // same command, which deletes a branch only after proving it merged
+        // or pushed — warn and continue so re-runs stay idempotent.
+        const branchList = await deps.runGitCommand(
+          `git branch --list ${JSON.stringify(slot.branch)}`,
+          worktree.parentRepo,
+        ) as { stdout?: unknown };
+        if (String(branchList?.stdout ?? '').trim().length === 0) {
+          const remote = await deps.runGitCommand(
+            `git ls-remote --heads origin ${JSON.stringify(slot.branch)}`,
+            worktree.parentRepo,
+          ) as { stdout?: unknown };
+          if (String(remote?.stdout ?? '').trim().length === 0) {
+            deps.console.log(chalk.yellow(
+              `Nested branch ${slot.branch} is absent from ${worktree.parentRepo} and origin — `
+              + 'assuming an earlier cleanup pass removed it after proving durability.',
+            ));
+          }
+          continue;
+        }
         const result = await deps.runGitCommand(
           `git rev-list --count ${JSON.stringify(worktree.featureBranch)}..${JSON.stringify(slot.branch)}`,
           worktree.parentRepo,
@@ -501,7 +525,37 @@ export async function swarmResetCommand(
   }
   for (const { slotWorkspace, branch, nested } of stalePolyrepoSlots) {
     for (const worktree of nested) {
-      await deps.runGitCommand(`git worktree remove --force ${JSON.stringify(worktree.dir)}`, worktree.parentRepo);
+      // PAN-3713: the nested list comes from project config, not from git, so
+      // it still names paths whose worktree registration an earlier merge/GC
+      // pass already removed. `git worktree remove` on such a path crashes
+      // with "fatal: '<path>' is not a working tree" — yet already-absent is
+      // exactly the desired postcondition. The preserve pass above proved the
+      // branch merged or pushed, so an unregistered path is a success: prune
+      // stale admin entries and continue with the remaining nested repos.
+      const registered = await isRegisteredWorktree(deps.runGitCommand, worktree.parentRepo, worktree.dir);
+      if (registered === null) {
+        deps.console.error(chalk.red(
+          `Aborting reset for ${issue}: worktree registration of ${worktree.dir} in ${worktree.parentRepo} `
+          + 'could not be determined. Nothing more was deleted; fix the repository state and re-run the reset.',
+        ));
+        return { ok: false };
+      }
+      if (registered) {
+        try {
+          await deps.runGitCommand(`git worktree remove --force ${JSON.stringify(worktree.dir)}`, worktree.parentRepo);
+        } catch (error) {
+          deps.console.error(chalk.red(
+            `Aborting reset for ${issue}: removing nested worktree ${worktree.dir} failed `
+            + `(${error instanceof Error ? error.message : String(error)}). Fix the failure and re-run the reset.`,
+          ));
+          return { ok: false };
+        }
+      } else {
+        await deps.runGitCommand('git worktree prune', worktree.parentRepo).catch(() => undefined);
+        deps.console.log(chalk.dim(
+          `Nested worktree ${worktree.dir} is no longer registered in ${worktree.parentRepo} — already removed.`,
+        ));
+      }
       await deps.runGitCommand(`git branch -D ${JSON.stringify(branch)}`, worktree.parentRepo).catch(() => undefined);
     }
     await deps.removeDirectory(slotWorkspace);

--- a/src/lib/cloister/deacon-swarm-gc.ts
+++ b/src/lib/cloister/deacon-swarm-gc.ts
@@ -303,8 +303,11 @@ async function removeSlotWorkspace(
  * `repoDir`, or null when the registration state cannot be determined. The
  * porcelain list always names at least the repository's own main worktree, so
  * a response with no `worktree` lines is an anomaly, not proof of "absent".
+ * Shared with `pan swarm reset` (PAN-3713), which must distinguish an
+ * already-unregistered nested worktree (the desired postcondition) from a
+ * genuine removal failure.
  */
-async function isRegisteredWorktree(
+export async function isRegisteredWorktree(
   runGitCommand: CoordinateSwarmSlotsDeps['runGitCommand'],
   repoDir: string,
   worktreeDir: string,

--- a/tests/unit/cli/commands/swarm.test.ts
+++ b/tests/unit/cli/commands/swarm.test.ts
@@ -726,9 +726,17 @@ describe('pan swarm reset (PAN-2214)', () => {
     slotAgents?: Array<{ slotIndex: number; agentId: string; status: string }>;
     liveSessions?: string[];
     status?: { deaconIgnored?: boolean } | null;
+    // PAN-3713: nested worktree registration per parent repo cwd, and whether
+    // nested slot branches still exist locally / on origin.
+    registeredNestedWorktrees?: Record<string, string[]>;
+    nestedBranchesPresent?: boolean;
+    nestedBranchesOnOrigin?: boolean;
+    // Ahead count returned for nested `feature..slot` rev-list probes.
+    nestedAheadCount?: string;
   } = {}): SwarmResetCommandDeps & { gitCalls: string[] } {
     const gitCalls: string[] = [];
     const branches = options.slotBranches ?? {};
+    const outerWorkspace = '/repo/workspaces/feature-pan-2203';
     const deps = {
       getReviewStatusSync: vi.fn(() => (options.status ?? null) as never),
       setDeaconIgnored: vi.fn(),
@@ -745,10 +753,17 @@ describe('pan swarm reset (PAN-2214)', () => {
       clearSupersededSwarmAttempts: vi.fn(),
       clearFailedMergeBlock: vi.fn(),
       getFailedMergeBlocks: vi.fn(() => [{ issueId: 'PAN-2203', itemId: 'wi-1', slotIndex: 1, note: 'conflict' }]),
-      runGitCommand: vi.fn(async (command: string) => {
+      runGitCommand: vi.fn(async (command: string, cwd?: string) => {
         gitCalls.push(command);
         if (command.startsWith('git for-each-ref')) {
           return { stdout: `${Object.keys(branches).join('\n')}\n` };
+        }
+        if (command.startsWith('git branch --list ')) {
+          const branch = JSON.parse(command.slice('git branch --list '.length)) as string;
+          return { stdout: options.nestedBranchesPresent === false ? '' : `${branch}\n` };
+        }
+        if (command.startsWith('git ls-remote ')) {
+          return { stdout: options.nestedBranchesOnOrigin ? 'abc123\trefs/heads/x\n' : '' };
         }
         if (command.startsWith('git rev-list --count HEAD..')) {
           for (const [branch, count] of Object.entries(branches)) {
@@ -757,10 +772,17 @@ describe('pan swarm reset (PAN-2214)', () => {
           return { stdout: '0\n' };
         }
         if (command.startsWith('git rev-list --count ')) {
-          return { stdout: '0\n' };
+          return { stdout: `${options.nestedAheadCount ?? '0'}\n` };
         }
         if (command === 'git worktree list --porcelain') {
-          const lines = ['worktree /repo/workspaces/feature-pan-2203'];
+          if (cwd && cwd !== outerWorkspace) {
+            // A parent repo's porcelain list names its own main worktree plus
+            // whatever nested slot worktrees remain registered (PAN-3713).
+            const lines = [`worktree ${cwd}`];
+            for (const path of options.registeredNestedWorktrees?.[cwd] ?? []) lines.push(`worktree ${path}`);
+            return { stdout: `${lines.join('\n')}\n` };
+          }
+          const lines = [`worktree ${outerWorkspace}`];
           for (const path of options.worktreeSlotPaths ?? []) lines.push(`worktree ${path}`);
           return { stdout: `${lines.join('\n')}\n` };
         }
@@ -802,8 +824,10 @@ describe('pan swarm reset (PAN-2214)', () => {
   });
 
   it('removes stale polyrepo slot directories and nested worktrees left by reset', async () => {
-    const deps = makeResetDeps();
     const slotWorkspace = '/repo/workspaces/feature-pan-2203-slot-4';
+    const deps = makeResetDeps({
+      registeredNestedWorktrees: { '/repo/api': [`${slotWorkspace}/api`] },
+    });
     deps.listSlotWorkspaceDirectories = vi.fn(() => [slotWorkspace]);
     deps.resolveSlotWorkspaceWorktrees = vi.fn(() => ({
       isPolyrepo: true,
@@ -823,6 +847,85 @@ describe('pan swarm reset (PAN-2214)', () => {
       '/repo/api',
     );
     expect(deps.removeDirectory).toHaveBeenCalledWith(slotWorkspace);
+  });
+
+  it('treats an already-unregistered nested worktree as success and continues cleanup (PAN-3713)', async () => {
+    const slotWorkspace = '/repo/workspaces/feature-pan-2203-slot-2';
+    // fe is still registered; api's worktree registration is already gone —
+    // the exact mix that crashed reset with "fatal: '<path>' is not a working tree".
+    const deps = makeResetDeps({
+      registeredNestedWorktrees: { '/repo/fe': [`${slotWorkspace}/fe`] },
+    });
+    deps.listSlotWorkspaceDirectories = vi.fn(() => [slotWorkspace]);
+    deps.resolveSlotWorkspaceWorktrees = vi.fn(() => ({
+      isPolyrepo: true,
+      nested: [
+        { repoKey: 'fe', dir: `${slotWorkspace}/fe`, parentRepo: '/repo/fe', featureBranch: 'feature/pan-2203' },
+        { repoKey: 'api', dir: `${slotWorkspace}/api`, parentRepo: '/repo/api', featureBranch: 'feature/pan-2203' },
+      ],
+    }));
+
+    const result = await swarmResetCommand('PAN-2203', {}, deps);
+
+    expect(result.ok).toBe(true);
+    // The registered nested worktree is removed through git…
+    expect(deps.runGitCommand).toHaveBeenCalledWith(
+      'git worktree remove --force "/repo/workspaces/feature-pan-2203-slot-2/fe"',
+      '/repo/fe',
+    );
+    // …the unregistered one is pruned, never force-removed (that call is the PAN-3713 crash)…
+    expect(deps.runGitCommand).not.toHaveBeenCalledWith(
+      'git worktree remove --force "/repo/workspaces/feature-pan-2203-slot-2/api"',
+      '/repo/api',
+    );
+    expect(deps.runGitCommand).toHaveBeenCalledWith('git worktree prune', '/repo/api');
+    // …both merged slot branches are deleted without a push, the slot
+    // directory is removed, and slot state is cleared through the writer.
+    expect(deps.runGitCommand).toHaveBeenCalledWith('git branch -D "feature/pan-2203-slot-2"', '/repo/fe');
+    expect(deps.runGitCommand).toHaveBeenCalledWith('git branch -D "feature/pan-2203-slot-2"', '/repo/api');
+    expect(deps.gitCalls.some(cmd => cmd.startsWith('git push'))).toBe(false);
+    expect(deps.removeDirectory).toHaveBeenCalledWith(slotWorkspace);
+    expect(deps.clearAllSlotAssignments).toHaveBeenCalledWith('/repo/workspaces/feature-pan-2203', 'PAN-2203');
+  });
+
+  it('still pushes an unmerged nested branch before removing its unregistered worktree (PAN-3713)', async () => {
+    const slotWorkspace = '/repo/workspaces/feature-pan-2203-slot-2';
+    // The nested slot branch exists locally with 2 commits the feature branch
+    // lacks; its worktree registration is already gone.
+    const deps = makeResetDeps({ nestedAheadCount: '2' });
+    deps.listSlotWorkspaceDirectories = vi.fn(() => [slotWorkspace]);
+    deps.resolveSlotWorkspaceWorktrees = vi.fn(() => ({
+      isPolyrepo: true,
+      nested: [
+        { repoKey: 'api', dir: `${slotWorkspace}/api`, parentRepo: '/repo/api', featureBranch: 'feature/pan-2203' },
+      ],
+    }));
+
+    const result = await swarmResetCommand('PAN-2203', {}, deps);
+
+    expect(result.ok).toBe(true);
+    expect(deps.runGitCommand).toHaveBeenCalledWith('git push origin "feature/pan-2203-slot-2"', '/repo/api');
+    expect(deps.removeDirectory).toHaveBeenCalledWith(slotWorkspace);
+  });
+
+  it('re-running reset after partial cleanup succeeds when nested branches are already gone (PAN-3713)', async () => {
+    const slotWorkspace = '/repo/workspaces/feature-pan-2203-slot-2';
+    const deps = makeResetDeps({ nestedBranchesPresent: false });
+    deps.listSlotWorkspaceDirectories = vi.fn(() => [slotWorkspace]);
+    deps.resolveSlotWorkspaceWorktrees = vi.fn(() => ({
+      isPolyrepo: true,
+      nested: [
+        { repoKey: 'api', dir: `${slotWorkspace}/api`, parentRepo: '/repo/api', featureBranch: 'feature/pan-2203' },
+      ],
+    }));
+
+    const result = await swarmResetCommand('PAN-2203', {}, deps);
+
+    expect(result.ok).toBe(true);
+    expect(deps.gitCalls.some(cmd => cmd.startsWith('git push'))).toBe(false);
+    expect(deps.removeDirectory).toHaveBeenCalledWith(slotWorkspace);
+    expect(deps.clearAllSlotAssignments).toHaveBeenCalledWith('/repo/workspaces/feature-pan-2203', 'PAN-2203');
+    expect(loggedText(deps)).toContain('absent from /repo/api and origin');
   });
 
   it('a push failure without --force aborts with the branch named and deletes nothing', async () => {


### PR DESCRIPTION
**Issue:** #3713


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved swarm reset cleanup for nested worktrees that are already unregistered or missing.
  - Prevented cleanup failures when nested branches no longer exist locally or remotely.
  - Ensured unmerged nested branches are preserved before cleanup.
  - Repeated swarm resets now complete successfully after earlier cleanup attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->