### PR TITLE
PAN-3743

### DIFF
--- a/docs/DASHBOARD-ARCHITECTURE.md
+++ b/docs/DASHBOARD-ARCHITECTURE.md
@@ -54,9 +54,10 @@ The dashboard server uses **Effect.js** for HTTP routes and structured RPC, plus
   `[db-jobs] slow: op=<operation> lane=<lane> waitMs=<n> runMs=<n> depth=<n>`.
   The line identifies whether queue delay or worker execution caused the slowdown.
 - `costReconcileSweep` walks and parses transcript files in the `long` lane. The main
-  thread requests bounded 250-event batches and records each batch through the canonical
-  write doors before requesting the next one. This limits worker transfer memory while
-  preserving EventBus publication and durable skip-cache updates.
+  thread records bounded 250-event progress batches through the canonical write doors and
+  acknowledges each batch before the worker continues its single-pass scan. This limits
+  transfer memory without repeated parsing while preserving EventBus publication and
+  durable skip-cache updates.
 
 **Issue views:** Rail, cockpit, and console issue surfaces share the kit documented in
 `docs/ISSUE-VIEW.md`. Route new issue sections through `IssueViewModel`, the shared

--- a/docs/DASHBOARD-ARCHITECTURE.md
+++ b/docs/DASHBOARD-ARCHITECTURE.md
@@ -47,15 +47,16 @@ The dashboard server uses **Effect.js** for HTTP routes and structured RPC, plus
 - The `read` lane handles interactive lookups, the `long` lane handles bulk scans and
   reconciliation, and the `semantic` lane isolates embedding and semantic-search work.
   This separation prevents a bulk job from delaying an operator-facing read.
-- Worker implementations live in `src/dashboard/server/workers/dashboard-db-worker.ts`.
-  Add each new operation to both the task contract and the worker dispatch table so the
-  main thread and worker remain type-safe.
+- Worker implementations live in `src/dashboard/server/services/dashboard-db-worker.ts`.
+  Add each new operation to both `dashboard-db-task.ts` and the worker dispatch table so
+  the main thread and worker remain type-safe.
 - Jobs that wait or run for more than one second emit
   `[db-jobs] slow: op=<operation> lane=<lane> waitMs=<n> runMs=<n> depth=<n>`.
   The line identifies whether queue delay or worker execution caused the slowdown.
 - `costReconcileSweep` walks and parses transcript files in the `long` lane. The main
-  thread records the returned cost events and skip verdicts through their canonical
-  write doors, preserving EventBus publication and durable cache updates.
+  thread requests bounded 250-event batches and records each batch through the canonical
+  write doors before requesting the next one. This limits worker transfer memory while
+  preserving EventBus publication and durable skip-cache updates.
 
 **Issue views:** Rail, cockpit, and console issue surfaces share the kit documented in
 `docs/ISSUE-VIEW.md`. Route new issue sections through `IssueViewModel`, the shared

--- a/docs/DASHBOARD-ARCHITECTURE.md
+++ b/docs/DASHBOARD-ARCHITECTURE.md
@@ -43,6 +43,20 @@ The dashboard server uses **Effect.js** for HTTP routes and structured RPC, plus
 - `wsTransport.ts` — Effect-based RPC client with auto-reconnection
 - Store: Zustand with shared reducers from `@overdeck/contracts`
 
+**DB job worker lanes:**
+- The `read` lane handles interactive lookups, the `long` lane handles bulk scans and
+  reconciliation, and the `semantic` lane isolates embedding and semantic-search work.
+  This separation prevents a bulk job from delaying an operator-facing read.
+- Worker implementations live in `src/dashboard/server/workers/dashboard-db-worker.ts`.
+  Add each new operation to both the task contract and the worker dispatch table so the
+  main thread and worker remain type-safe.
+- Jobs that wait or run for more than one second emit
+  `[db-jobs] slow: op=<operation> lane=<lane> waitMs=<n> runMs=<n> depth=<n>`.
+  The line identifies whether queue delay or worker execution caused the slowdown.
+- `costReconcileSweep` walks and parses transcript files in the `long` lane. The main
+  thread records the returned cost events and skip verdicts through their canonical
+  write doors, preserving EventBus publication and durable cache updates.
+
 **Issue views:** Rail, cockpit, and console issue surfaces share the kit documented in
 `docs/ISSUE-VIEW.md`. Route new issue sections through `IssueViewModel`, the shared
 components, and `DENSITY_SECTIONS`; update the inventory and real `data-section`
@@ -56,4 +70,3 @@ marker so the no-loss gate proves that no existing surface disappeared.
 - The planning launcher script MUST export TERM/COLORTERM/LANG for Claude Code rendering.
 - Planning sessions use `remain-on-exit on` + `destroy-unattached off` so the session
   survives after the agent exits, until the user clicks Done.
-

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -89,6 +89,14 @@ Raw counts and timings are never sent. Pipeline attribution is emitted only
 after the canonical pipeline-membership resolver confirms that the issue is in
 the pipeline, so stale agent rows cannot supply harness or model metadata.
 
+## Local DB job diagnostics
+
+The dashboard logs slow worker jobs locally as
+`[db-jobs] slow: op=<operation> lane=<lane> waitMs=<n> runMs=<n> depth=<n>` when
+queue wait or execution exceeds one second. Use the lane, wait time, run time,
+and queue depth to distinguish worker congestion from a slow operation. These
+raw timings stay in local logs and are not sent as anonymous telemetry.
+
 Node events also receive the anonymous install ID and the centrally stamped
 `$process_person_profile: false`, platform, architecture, Overdeck version, and
 client type. The frontend registers the same install ID and configures PostHog

--- a/src/cli/commands/__tests__/cost-backfill.test.ts
+++ b/src/cli/commands/__tests__/cost-backfill.test.ts
@@ -97,7 +97,7 @@ describe('pan cost backfill', () => {
     }
   });
 
-  it('--write imports a synthetic Claude event once and reports duplicates on rerun', async () => {
+  it('--write imports a synthetic Claude event once and cache-skips it on rerun', async () => {
     const home = makeFixtureHome();
     vi.spyOn(console, 'log').mockImplementation(() => undefined);
 
@@ -119,7 +119,8 @@ describe('pan cost backfill', () => {
       expect(second[0]).toMatchObject({
         source: 'claude',
         eventsImported: 0,
-        duplicatesSkipped: 1,
+        duplicatesSkipped: 0,
+        cacheSkipped: 1,
       });
       expect(rows).toEqual([
         {

--- a/src/cli/commands/cost.ts
+++ b/src/cli/commands/cost.ts
@@ -73,6 +73,7 @@ interface BackfillSourceSummary {
   sessionsScanned: number;
   eventsImported: number;
   duplicatesSkipped: number;
+  cacheSkipped: number;
   errors: number;
   earliestEventTs: string | null;
   latestEventTs: string | null;
@@ -84,6 +85,7 @@ function fromClaudeReconcile(result: ReconcileResult): BackfillSourceSummary {
     sessionsScanned: result.sessionsScanned,
     eventsImported: result.eventsImported,
     duplicatesSkipped: result.duplicatesSkipped,
+    cacheSkipped: result.cacheSkipped,
     errors: result.errors.length,
     earliestEventTs: result.earliestEventTs,
     latestEventTs: result.latestEventTs,
@@ -96,6 +98,7 @@ function fromDoorReconcile(source: 'ohmypi' | 'codex', result: CostReconcileSumm
     sessionsScanned: result.sessionsScanned,
     eventsImported: result.eventsImported,
     duplicatesSkipped: result.duplicatesSkipped,
+    cacheSkipped: result.cacheSkipped,
     errors: result.errors.length,
     earliestEventTs: result.earliestEventTs,
     latestEventTs: result.latestEventTs,
@@ -111,6 +114,7 @@ function printBackfillSummary(summaries: BackfillSourceSummary[], write: boolean
     console.log(`  Sessions scanned:     ${summary.sessionsScanned}`);
     console.log(`  ${importedLabel}:        ${write ? chalk.green(summary.eventsImported) : chalk.yellow(summary.eventsImported)}`);
     console.log(`  Duplicates skipped:   ${chalk.dim(summary.duplicatesSkipped)}`);
+    console.log(`  Cache skipped:        ${chalk.dim(summary.cacheSkipped)}`);
     console.log(`  Errors:               ${summary.errors === 0 ? summary.errors : chalk.yellow(summary.errors)}`);
     console.log(`  Earliest event ts:    ${summary.earliestEventTs ?? chalk.dim('none')}`);
     console.log(`  Latest event ts:      ${summary.latestEventTs ?? chalk.dim('none')}`);

--- a/src/dashboard/server/services/cost-reconcile-service.ts
+++ b/src/dashboard/server/services/cost-reconcile-service.ts
@@ -1,3 +1,8 @@
+/**
+ * Periodic cost reconciliation delegates transcript walking and parsing to the
+ * long DB worker lane. The main thread records returned events through the cost
+ * write door and persists exact path/mtime/size skip verdicts for later sweeps.
+ */
 import { Effect } from 'effect';
 import { reclassifyUnknownCostEventsSync } from '../../../lib/costs/attribution.js';
 import {

--- a/src/dashboard/server/services/cost-reconcile-service.ts
+++ b/src/dashboard/server/services/cost-reconcile-service.ts
@@ -12,10 +12,11 @@ async function runCostReconcileOnce(reason: 'startup' | 'interval'): Promise<voi
   if (inFlight) return inFlight;
   inFlight = (async () => {
     const result = await reconcilePiTranscripts();
-    if (result.eventsImported > 0 || result.errors.length > 0) {
+    if (result.eventsImported > 0 || result.cacheSkipped > 0 || result.errors.length > 0) {
       console.log(
         `[cost-reconciler] ${reason} sweep: ${result.eventsImported} imported, ` +
-        `${result.duplicatesSkipped} duplicate(s), ${result.errors.length} error(s)`,
+        `${result.cacheSkipped} cache-skipped, ${result.duplicatesSkipped} duplicate(s), ` +
+        `${result.errors.length} error(s)`,
       );
     }
     if (result.errors.length > 0) {

--- a/src/dashboard/server/services/cost-reconcile-service.ts
+++ b/src/dashboard/server/services/cost-reconcile-service.ts
@@ -1,6 +1,9 @@
 import { Effect } from 'effect';
 import { reclassifyUnknownCostEventsSync } from '../../../lib/costs/attribution.js';
-import { reconcilePiTranscripts } from '../../../lib/costs/reconciler.js';
+import {
+  recordCostEventsThroughOverdeck,
+  type PiCollectResult,
+} from '../../../lib/costs/reconciler.js';
 import { CostDoorLive, CostWriter, type CostEvent, type SkipVerdictEntry } from '../../../lib/overdeck/cost.js';
 import { recordSkipVerdict } from '../../../lib/costs/skip-cache.js';
 import { runDashboardDbJob } from './dashboard-db-task.js';
@@ -13,7 +16,21 @@ let inFlight: Promise<void> | null = null;
 async function runCostReconcileOnce(reason: 'startup' | 'interval'): Promise<void> {
   if (inFlight) return inFlight;
   inFlight = (async () => {
-    const result = await reconcilePiTranscripts();
+    const piCollected = await runDashboardDbJob<PiCollectResult>('costReconcileSweep', { source: 'pi' });
+    const result = {
+      eventsImported: 0,
+      duplicatesSkipped: 0,
+      cacheSkipped: piCollected.stats.cacheSkipped,
+      errors: piCollected.errors,
+    };
+    for (const { event, sourceFile } of piCollected.events) {
+      const recorded = await recordCostEventsThroughOverdeck([event], sourceFile);
+      result.eventsImported += recorded.inserted;
+      result.duplicatesSkipped += recorded.duplicates;
+    }
+    for (const verdict of piCollected.verdicts) {
+      recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
+    }
     if (result.eventsImported > 0 || result.cacheSkipped > 0 || result.errors.length > 0) {
       console.log(
         `[cost-reconciler] ${reason} sweep: ${result.eventsImported} imported, ` +

--- a/src/dashboard/server/services/cost-reconcile-service.ts
+++ b/src/dashboard/server/services/cost-reconcile-service.ts
@@ -33,9 +33,10 @@ async function runCostReconcileOnce(reason: 'startup' | 'interval'): Promise<voi
           Effect.provide(CostDoorLive),
         ),
       );
-      if (codexResult.imported > 0) {
-        console.log(`[cost-reconciler] ${reason} codex sweep: ${codexResult.imported} imported`);
-      }
+      console.log(
+        `[cost-reconciler] ${reason} codex sweep: ${codexResult.sessionsScanned} scanned, ` +
+        `${codexResult.cacheSkipped} cache-skipped, ${codexResult.imported} imported`,
+      );
     } catch (err) {
       console.warn('[cost-reconciler] codex sweep failed:', err instanceof Error ? err.message : err);
     }

--- a/src/dashboard/server/services/cost-reconcile-service.ts
+++ b/src/dashboard/server/services/cost-reconcile-service.ts
@@ -14,6 +14,8 @@ import { recordSkipVerdict } from '../../../lib/costs/skip-cache.js';
 import { runDashboardDbJob } from './dashboard-db-task.js';
 
 const RECONCILE_INTERVAL_MS = 5 * 60_000;
+const RECONCILE_BATCH_EVENTS = 250;
+type ReconcileCursor = { file: string; eventOffset: number };
 
 let timer: ReturnType<typeof setInterval> | null = null;
 let inFlight: Promise<void> | null = null;
@@ -21,21 +23,29 @@ let inFlight: Promise<void> | null = null;
 async function runCostReconcileOnce(reason: 'startup' | 'interval'): Promise<void> {
   if (inFlight) return inFlight;
   inFlight = (async () => {
-    const piCollected = await runDashboardDbJob<PiCollectResult>('costReconcileSweep', { source: 'pi' });
     const result = {
       eventsImported: 0,
       duplicatesSkipped: 0,
-      cacheSkipped: piCollected.stats.cacheSkipped,
-      errors: piCollected.errors,
+      cacheSkipped: 0,
+      errors: [] as PiCollectResult['errors'],
     };
-    for (const { event, sourceFile } of piCollected.events) {
-      const recorded = await recordCostEventsThroughOverdeck([event], sourceFile);
-      result.eventsImported += recorded.inserted;
-      result.duplicatesSkipped += recorded.duplicates;
-    }
-    for (const verdict of piCollected.verdicts) {
-      recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
-    }
+    let piCursor: ReconcileCursor | undefined;
+    do {
+      const piCollected = await runDashboardDbJob<PiCollectResult>('costReconcileSweep', {
+        source: 'pi', cursor: piCursor, maxEvents: RECONCILE_BATCH_EVENTS,
+      });
+      result.cacheSkipped += piCollected.stats.cacheSkipped;
+      result.errors.push(...piCollected.errors);
+      for (const { event, sourceFile } of piCollected.events) {
+        const recorded = await recordCostEventsThroughOverdeck([event], sourceFile);
+        result.eventsImported += recorded.inserted;
+        result.duplicatesSkipped += recorded.duplicates;
+      }
+      for (const verdict of piCollected.verdicts) {
+        recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
+      }
+      piCursor = piCollected.done === false ? piCollected.nextCursor ?? undefined : undefined;
+    } while (piCursor);
     if (result.eventsImported > 0 || result.cacheSkipped > 0 || result.errors.length > 0) {
       console.log(
         `[cost-reconciler] ${reason} sweep: ${result.eventsImported} imported, ` +
@@ -53,23 +63,36 @@ async function runCostReconcileOnce(reason: 'startup' | 'interval'): Promise<voi
       console.log(`[cost-reconciler] ${reason} UNKNOWN backfill: ${backfillResult.updated} updated`);
     }
     try {
-      const codexResult = await runDashboardDbJob<{
+      type CodexBatch = {
         events: CostEvent[];
         verdicts: SkipVerdictEntry[];
         stats: { scanned: number; cacheSkipped: number };
-      }>('costReconcileSweep', { source: 'codex' });
+        nextCursor: ReconcileCursor | null;
+        done: boolean;
+      };
       let imported = 0;
-      for (const event of codexResult.events) {
-        const normalized = { ...event, ts: new Date(event.ts) };
-        if (await Effect.runPromise(CostWriter.use(writer => writer.record(normalized)).pipe(
-          Effect.provide(CostDoorLive)))) imported++;
-      }
-      for (const verdict of codexResult.verdicts) {
-        recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
-      }
+      let scanned = 0;
+      let cacheSkipped = 0;
+      let codexCursor: ReconcileCursor | undefined;
+      do {
+        const codexResult = await runDashboardDbJob<CodexBatch>('costReconcileSweep', {
+          source: 'codex', cursor: codexCursor, maxEvents: RECONCILE_BATCH_EVENTS,
+        });
+        scanned += codexResult.stats.scanned;
+        cacheSkipped += codexResult.stats.cacheSkipped;
+        for (const event of codexResult.events) {
+          const normalized = { ...event, ts: new Date(event.ts) };
+          if (await Effect.runPromise(CostWriter.use(writer => writer.record(normalized)).pipe(
+            Effect.provide(CostDoorLive)))) imported++;
+        }
+        for (const verdict of codexResult.verdicts) {
+          recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
+        }
+        codexCursor = codexResult.done === false ? codexResult.nextCursor ?? undefined : undefined;
+      } while (codexCursor);
       console.log(
-        `[cost-reconciler] ${reason} codex sweep: ${codexResult.stats.scanned} scanned, ` +
-        `${codexResult.stats.cacheSkipped} cache-skipped, ${imported} imported`,
+        `[cost-reconciler] ${reason} codex sweep: ${scanned} scanned, ` +
+        `${cacheSkipped} cache-skipped, ${imported} imported`,
       );
     } catch (err) {
       console.warn('[cost-reconciler] codex sweep failed:', err instanceof Error ? err.message : err);

--- a/src/dashboard/server/services/cost-reconcile-service.ts
+++ b/src/dashboard/server/services/cost-reconcile-service.ts
@@ -7,6 +7,7 @@ import { Effect } from 'effect';
 import { reclassifyUnknownCostEventsSync } from '../../../lib/costs/attribution.js';
 import {
   recordCostEventsThroughOverdeck,
+  type PiCollectBatch,
   type PiCollectResult,
 } from '../../../lib/costs/reconciler.js';
 import { CostDoorLive, CostWriter, type CostEvent, type SkipVerdictEntry } from '../../../lib/overdeck/cost.js';
@@ -15,7 +16,6 @@ import { runDashboardDbJob } from './dashboard-db-task.js';
 
 const RECONCILE_INTERVAL_MS = 5 * 60_000;
 const RECONCILE_BATCH_EVENTS = 250;
-type ReconcileCursor = { file: string; eventOffset: number };
 
 let timer: ReturnType<typeof setInterval> | null = null;
 let inFlight: Promise<void> | null = null;
@@ -29,23 +29,21 @@ async function runCostReconcileOnce(reason: 'startup' | 'interval'): Promise<voi
       cacheSkipped: 0,
       errors: [] as PiCollectResult['errors'],
     };
-    let piCursor: ReconcileCursor | undefined;
-    do {
-      const piCollected = await runDashboardDbJob<PiCollectResult>('costReconcileSweep', {
-        source: 'pi', cursor: piCursor, maxEvents: RECONCILE_BATCH_EVENTS,
-      });
-      result.cacheSkipped += piCollected.stats.cacheSkipped;
-      result.errors.push(...piCollected.errors);
-      for (const { event, sourceFile } of piCollected.events) {
+    const piCollected = await runDashboardDbJob<PiCollectResult>('costReconcileSweep', {
+      source: 'pi', maxEvents: RECONCILE_BATCH_EVENTS,
+    }, async (progress) => {
+      const batch = progress as PiCollectBatch;
+      for (const { event, sourceFile } of batch.events) {
         const recorded = await recordCostEventsThroughOverdeck([event], sourceFile);
         result.eventsImported += recorded.inserted;
         result.duplicatesSkipped += recorded.duplicates;
       }
-      for (const verdict of piCollected.verdicts) {
+      for (const verdict of batch.verdicts) {
         recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
       }
-      piCursor = piCollected.done === false ? piCollected.nextCursor ?? undefined : undefined;
-    } while (piCursor);
+    });
+    result.cacheSkipped += piCollected.stats.cacheSkipped;
+    result.errors.push(...piCollected.errors);
     if (result.eventsImported > 0 || result.cacheSkipped > 0 || result.errors.length > 0) {
       console.log(
         `[cost-reconciler] ${reason} sweep: ${result.eventsImported} imported, ` +
@@ -66,33 +64,26 @@ async function runCostReconcileOnce(reason: 'startup' | 'interval'): Promise<voi
       type CodexBatch = {
         events: CostEvent[];
         verdicts: SkipVerdictEntry[];
-        stats: { scanned: number; cacheSkipped: number };
-        nextCursor: ReconcileCursor | null;
-        done: boolean;
       };
       let imported = 0;
-      let scanned = 0;
-      let cacheSkipped = 0;
-      let codexCursor: ReconcileCursor | undefined;
-      do {
-        const codexResult = await runDashboardDbJob<CodexBatch>('costReconcileSweep', {
-          source: 'codex', cursor: codexCursor, maxEvents: RECONCILE_BATCH_EVENTS,
-        });
-        scanned += codexResult.stats.scanned;
-        cacheSkipped += codexResult.stats.cacheSkipped;
-        for (const event of codexResult.events) {
+      const codexResult = await runDashboardDbJob<{
+        stats: { scanned: number; cacheSkipped: number };
+      }>('costReconcileSweep', {
+        source: 'codex', maxEvents: RECONCILE_BATCH_EVENTS,
+      }, async (progress) => {
+        const batch = progress as CodexBatch;
+        for (const event of batch.events) {
           const normalized = { ...event, ts: new Date(event.ts) };
           if (await Effect.runPromise(CostWriter.use(writer => writer.record(normalized)).pipe(
             Effect.provide(CostDoorLive)))) imported++;
         }
-        for (const verdict of codexResult.verdicts) {
+        for (const verdict of batch.verdicts) {
           recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
         }
-        codexCursor = codexResult.done === false ? codexResult.nextCursor ?? undefined : undefined;
-      } while (codexCursor);
+      });
       console.log(
-        `[cost-reconciler] ${reason} codex sweep: ${scanned} scanned, ` +
-        `${cacheSkipped} cache-skipped, ${imported} imported`,
+        `[cost-reconciler] ${reason} codex sweep: ${codexResult.stats.scanned} scanned, ` +
+        `${codexResult.stats.cacheSkipped} cache-skipped, ${imported} imported`,
       );
     } catch (err) {
       console.warn('[cost-reconciler] codex sweep failed:', err instanceof Error ? err.message : err);

--- a/src/dashboard/server/services/cost-reconcile-service.ts
+++ b/src/dashboard/server/services/cost-reconcile-service.ts
@@ -1,7 +1,9 @@
 import { Effect } from 'effect';
 import { reclassifyUnknownCostEventsSync } from '../../../lib/costs/attribution.js';
 import { reconcilePiTranscripts } from '../../../lib/costs/reconciler.js';
-import { CostDoorLive, CostWriter } from '../../../lib/overdeck/cost.js';
+import { CostDoorLive, CostWriter, type CostEvent, type SkipVerdictEntry } from '../../../lib/overdeck/cost.js';
+import { recordSkipVerdict } from '../../../lib/costs/skip-cache.js';
+import { runDashboardDbJob } from './dashboard-db-task.js';
 
 const RECONCILE_INTERVAL_MS = 5 * 60_000;
 
@@ -29,14 +31,23 @@ async function runCostReconcileOnce(reason: 'startup' | 'interval'): Promise<voi
       console.log(`[cost-reconciler] ${reason} UNKNOWN backfill: ${backfillResult.updated} updated`);
     }
     try {
-      const codexResult = await Effect.runPromise(
-        CostWriter.use((writer) => writer.reconcile({ source: 'codex' })).pipe(
-          Effect.provide(CostDoorLive),
-        ),
-      );
+      const codexResult = await runDashboardDbJob<{
+        events: CostEvent[];
+        verdicts: SkipVerdictEntry[];
+        stats: { scanned: number; cacheSkipped: number };
+      }>('costReconcileSweep', { source: 'codex' });
+      let imported = 0;
+      for (const event of codexResult.events) {
+        const normalized = { ...event, ts: new Date(event.ts) };
+        if (await Effect.runPromise(CostWriter.use(writer => writer.record(normalized)).pipe(
+          Effect.provide(CostDoorLive)))) imported++;
+      }
+      for (const verdict of codexResult.verdicts) {
+        recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
+      }
       console.log(
-        `[cost-reconciler] ${reason} codex sweep: ${codexResult.sessionsScanned} scanned, ` +
-        `${codexResult.cacheSkipped} cache-skipped, ${codexResult.imported} imported`,
+        `[cost-reconciler] ${reason} codex sweep: ${codexResult.stats.scanned} scanned, ` +
+        `${codexResult.stats.cacheSkipped} cache-skipped, ${imported} imported`,
       );
     } catch (err) {
       console.warn('[cost-reconciler] codex sweep failed:', err instanceof Error ? err.message : err);

--- a/src/dashboard/server/services/dashboard-db-task.ts
+++ b/src/dashboard/server/services/dashboard-db-task.ts
@@ -72,6 +72,7 @@ interface WorkerResponse {
   ok?: boolean;
   result?: unknown;
   progress?: unknown;
+  progressSeq?: number;
   startedAt?: number;
   finishedAt?: number;
   error?: {
@@ -182,6 +183,8 @@ function getWorker(lane: WorkerLane): Worker {
         for (const listener of job.progressListeners) {
           await listener(message.progress);
         }
+      }).finally(() => {
+        worker.postMessage({ id: message.id, ack: message.progressSeq });
       });
       return;
     }
@@ -291,8 +294,8 @@ async function executeInline(
     }
     case 'costReconcileSweep':
       return (payload as { source: 'codex' | 'pi' }).source === 'pi'
-        ? collectPiCostEvents(payload as { cursor?: { file: string; eventOffset: number }; maxEvents?: number })
-        : collectCodexCostEvents(payload as { cursor?: { file: string; eventOffset: number }; maxEvents?: number });
+        ? collectPiCostEvents({ ...(payload as { maxEvents?: number }), onBatch: async batch => onProgress?.(batch) })
+        : collectCodexCostEvents({ ...(payload as { maxEvents?: number }), onBatch: async batch => onProgress?.(batch) });
   }
 }
 

--- a/src/dashboard/server/services/dashboard-db-task.ts
+++ b/src/dashboard/server/services/dashboard-db-task.ts
@@ -291,8 +291,8 @@ async function executeInline(
     }
     case 'costReconcileSweep':
       return (payload as { source: 'codex' | 'pi' }).source === 'pi'
-        ? collectPiCostEvents()
-        : collectCodexCostEvents();
+        ? collectPiCostEvents(payload as { cursor?: { file: string; eventOffset: number }; maxEvents?: number })
+        : collectCodexCostEvents(payload as { cursor?: { file: string; eventOffset: number }; maxEvents?: number });
   }
 }
 

--- a/src/dashboard/server/services/dashboard-db-task.ts
+++ b/src/dashboard/server/services/dashboard-db-task.ts
@@ -22,6 +22,7 @@ import type { EnrichOptions } from '../../../lib/conversations/enrichment/index.
 import { embedSessions } from '../../../lib/conversations/embeddings/index.js';
 import type { EmbedSessionsOptions } from '../../../lib/conversations/embeddings/index.js';
 import { listSubstrateBugWeights } from '../../../lib/overdeck/substrate-bug-weights-service.js';
+import { collectCodexCostEvents } from '../../../lib/overdeck/cost.js';
 
 export type DashboardDbOperation =
   | 'getDiscoveredStats'
@@ -42,7 +43,8 @@ export type DashboardDbOperation =
   | 'listSubstrateBugWeights'
   | 'getArtifactBySlug'
   | 'listArtifactsForWorkspaceOrIssue'
-  | 'unshareArtifactBySlug';
+  | 'unshareArtifactBySlug'
+  | 'costReconcileSweep';
 
 type ProgressHandler = (progress: unknown) => void | Promise<void>;
 type WorkerLane = 'read' | 'long' | 'semantic';
@@ -126,8 +128,9 @@ function coalescingKey(operation: DashboardDbOperation, payload: unknown): strin
   return `${operation}:${stableStringify(payload)}`;
 }
 
-function workerLane(operation: DashboardDbOperation): WorkerLane {
+export function workerLane(operation: DashboardDbOperation): WorkerLane {
   if (operation === 'searchSessionsSemantic') return 'semantic';
+  if (operation === 'costReconcileSweep') return 'long';
   return COALESCED_OPERATIONS.has(operation) ? 'long' : 'read';
 }
 
@@ -261,6 +264,8 @@ async function runInline(
       const { unshareArtifactBySlugJob } = await import('./artifact-index-jobs.js');
       return unshareArtifactBySlugJob(payload as string);
     }
+    case 'costReconcileSweep':
+      return collectCodexCostEvents();
   }
 }
 

--- a/src/dashboard/server/services/dashboard-db-task.ts
+++ b/src/dashboard/server/services/dashboard-db-task.ts
@@ -23,6 +23,7 @@ import { embedSessions } from '../../../lib/conversations/embeddings/index.js';
 import type { EmbedSessionsOptions } from '../../../lib/conversations/embeddings/index.js';
 import { listSubstrateBugWeights } from '../../../lib/overdeck/substrate-bug-weights-service.js';
 import { collectCodexCostEvents } from '../../../lib/overdeck/cost.js';
+import { collectPiCostEvents } from '../../../lib/costs/reconciler.js';
 
 export type DashboardDbOperation =
   | 'getDiscoveredStats'
@@ -265,7 +266,9 @@ async function runInline(
       return unshareArtifactBySlugJob(payload as string);
     }
     case 'costReconcileSweep':
-      return collectCodexCostEvents();
+      return (payload as { source: 'codex' | 'pi' }).source === 'pi'
+        ? collectPiCostEvents()
+        : collectCodexCostEvents();
   }
 }
 

--- a/src/dashboard/server/services/dashboard-db-task.ts
+++ b/src/dashboard/server/services/dashboard-db-task.ts
@@ -48,7 +48,7 @@ export type DashboardDbOperation =
   | 'costReconcileSweep';
 
 type ProgressHandler = (progress: unknown) => void | Promise<void>;
-type WorkerLane = 'read' | 'long' | 'semantic';
+export type WorkerLane = 'read' | 'long' | 'semantic';
 
 interface PendingJob {
   lane: WorkerLane;
@@ -58,6 +58,7 @@ interface PendingJob {
   progressListeners: Set<ProgressHandler>;
   progressChain: Promise<void>;
   timeout: NodeJS.Timeout | null;
+  enqueuedAt: number;
 }
 
 interface SharedJob {
@@ -71,6 +72,8 @@ interface WorkerResponse {
   ok?: boolean;
   result?: unknown;
   progress?: unknown;
+  startedAt?: number;
+  finishedAt?: number;
   error?: {
     name?: string;
     message?: string;
@@ -95,6 +98,17 @@ const workers: Record<WorkerLane, Worker | null> = { read: null, long: null, sem
 const pending = new Map<string, PendingJob>();
 const sharedJobs = new Map<string, SharedJob>();
 let latestSemanticJobId: string | null = null;
+
+export function formatSlowJobLine(input: {
+  op: DashboardDbOperation;
+  lane: WorkerLane;
+  waitMs: number;
+  runMs: number;
+  depth: number;
+}): string | null {
+  if (input.waitMs <= 1_000 && input.runMs <= 1_000) return null;
+  return `[db-jobs] slow: op=${input.op} lane=${input.lane} waitMs=${input.waitMs} runMs=${input.runMs} depth=${input.depth}`;
+}
 
 function workerScriptUrl(): URL {
   return import.meta.url.endsWith('.ts')
@@ -175,6 +189,16 @@ function getWorker(lane: WorkerLane): Worker {
     pending.delete(message.id);
     if (job.timeout) clearTimeout(job.timeout);
     if (job.lane === 'semantic' && latestSemanticJobId === message.id) latestSemanticJobId = null;
+    if (message.startedAt !== undefined && message.finishedAt !== undefined) {
+      const line = formatSlowJobLine({
+        op: job.operation,
+        lane: job.lane,
+        waitMs: message.startedAt - job.enqueuedAt,
+        runMs: message.finishedAt - message.startedAt,
+        depth: [...pending.values()].filter(pendingJob => pendingJob.lane === job.lane).length,
+      });
+      if (line) console.warn(line);
+    }
 
     if (message.ok) {
       job.progressChain.then(() => job.resolve(message.result), job.reject);
@@ -206,7 +230,7 @@ function getWorker(lane: WorkerLane): Worker {
   return worker;
 }
 
-async function runInline(
+async function executeInline(
   operation: DashboardDbOperation,
   payload: unknown,
   onProgress?: (progress: unknown) => void | Promise<void>,
@@ -272,6 +296,23 @@ async function runInline(
   }
 }
 
+async function runInline(
+  operation: DashboardDbOperation,
+  payload: unknown,
+  onProgress?: (progress: unknown) => void | Promise<void>,
+): Promise<unknown> {
+  const startedAt = Date.now();
+  try {
+    return await executeInline(operation, payload, onProgress);
+  } finally {
+    const line = formatSlowJobLine({
+      op: operation, lane: workerLane(operation), waitMs: 0,
+      runMs: Date.now() - startedAt, depth: 0,
+    });
+    if (line) console.warn(line);
+  }
+}
+
 export function runDashboardDbJob<T>(
   operation: DashboardDbOperation,
   payload?: unknown,
@@ -324,6 +365,7 @@ export function runDashboardDbJob<T>(
       progressListeners,
       progressChain: Promise.resolve(),
       timeout,
+      enqueuedAt: Date.now(),
     });
     getWorker(lane).postMessage({ id, operation, payload });
   });

--- a/src/dashboard/server/services/dashboard-db-worker.ts
+++ b/src/dashboard/server/services/dashboard-db-worker.ts
@@ -22,6 +22,7 @@ import { embedSessions } from '../../../lib/conversations/embeddings/index.js';
 import type { EmbedSessionsOptions } from '../../../lib/conversations/embeddings/index.js';
 import { listSubstrateBugWeights } from '../../../lib/overdeck/substrate-bug-weights-service.js';
 import { collectCodexCostEvents } from '../../../lib/overdeck/cost.js';
+import { collectPiCostEvents } from '../../../lib/costs/reconciler.js';
 
 type DashboardDbOperation =
   | 'getDiscoveredStats'
@@ -123,7 +124,9 @@ async function runJob(
       return unshareArtifactBySlugJob(payload as string);
     }
     case 'costReconcileSweep':
-      return collectCodexCostEvents();
+      return (payload as { source: 'codex' | 'pi' }).source === 'pi'
+        ? collectPiCostEvents()
+        : collectCodexCostEvents();
   }
 }
 

--- a/src/dashboard/server/services/dashboard-db-worker.ts
+++ b/src/dashboard/server/services/dashboard-db-worker.ts
@@ -125,8 +125,8 @@ async function runJob(
     }
     case 'costReconcileSweep':
       return (payload as { source: 'codex' | 'pi' }).source === 'pi'
-        ? collectPiCostEvents()
-        : collectCodexCostEvents();
+        ? collectPiCostEvents(payload as { cursor?: { file: string; eventOffset: number }; maxEvents?: number })
+        : collectCodexCostEvents(payload as { cursor?: { file: string; eventOffset: number }; maxEvents?: number });
   }
 }
 

--- a/src/dashboard/server/services/dashboard-db-worker.ts
+++ b/src/dashboard/server/services/dashboard-db-worker.ts
@@ -21,6 +21,7 @@ import type { EnrichOptions } from '../../../lib/conversations/enrichment/index.
 import { embedSessions } from '../../../lib/conversations/embeddings/index.js';
 import type { EmbedSessionsOptions } from '../../../lib/conversations/embeddings/index.js';
 import { listSubstrateBugWeights } from '../../../lib/overdeck/substrate-bug-weights-service.js';
+import { collectCodexCostEvents } from '../../../lib/overdeck/cost.js';
 
 type DashboardDbOperation =
   | 'getDiscoveredStats'
@@ -41,7 +42,8 @@ type DashboardDbOperation =
   | 'listSubstrateBugWeights'
   | 'getArtifactBySlug'
   | 'listArtifactsForWorkspaceOrIssue'
-  | 'unshareArtifactBySlug';
+  | 'unshareArtifactBySlug'
+  | 'costReconcileSweep';
 
 interface DashboardDbRequest {
   id: string;
@@ -120,6 +122,8 @@ async function runJob(
       const { unshareArtifactBySlugJob } = await import('./artifact-index-jobs.js');
       return unshareArtifactBySlugJob(payload as string);
     }
+    case 'costReconcileSweep':
+      return collectCodexCostEvents();
   }
 }
 

--- a/src/dashboard/server/services/dashboard-db-worker.ts
+++ b/src/dashboard/server/services/dashboard-db-worker.ts
@@ -135,13 +135,16 @@ let activeJobs = 0;
 const MAX_CONCURRENT_JOBS_PER_LANE = 1;
 
 async function execute(message: DashboardDbRequest): Promise<void> {
+  const startedAt = Date.now();
   try {
     const result = await runJob(message.id, message.operation, message.payload);
-    parentPort?.postMessage({ id: message.id, ok: true, result });
+    parentPort?.postMessage({ id: message.id, ok: true, result, startedAt, finishedAt: Date.now() });
   } catch (err) {
     parentPort?.postMessage({
       id: message.id,
       ok: false,
+      startedAt,
+      finishedAt: Date.now(),
       error: {
         name: err instanceof Error ? err.name : 'Error',
         message: err instanceof Error ? err.message : String(err),

--- a/src/dashboard/server/services/dashboard-db-worker.ts
+++ b/src/dashboard/server/services/dashboard-db-worker.ts
@@ -52,6 +52,14 @@ interface DashboardDbRequest {
   payload: unknown;
 }
 
+interface DashboardDbAck {
+  id: string;
+  ack: number;
+}
+
+const progressAcks = new Map<string, () => void>();
+let progressSequence = 0;
+
 function aggregateDiscoveredSessionCostByPayload(payload: unknown) {
   if (typeof payload === 'string') {
     return aggregateDiscoveredSessionCostBy(payload as 'workspace' | 'model' | 'day' | 'month');
@@ -65,8 +73,12 @@ async function runJob(
   operation: DashboardDbOperation,
   payload: unknown,
 ): Promise<unknown> {
-  const emitProgress = (progress: unknown) => {
-    parentPort?.postMessage({ id, progress });
+  const emitProgress = (progress: unknown): Promise<void> => {
+    const progressSeq = ++progressSequence;
+    return new Promise(resolve => {
+      progressAcks.set(`${id}:${progressSeq}`, resolve);
+      parentPort?.postMessage({ id, progress, progressSeq });
+    });
   };
 
   switch (operation) {
@@ -125,8 +137,8 @@ async function runJob(
     }
     case 'costReconcileSweep':
       return (payload as { source: 'codex' | 'pi' }).source === 'pi'
-        ? collectPiCostEvents(payload as { cursor?: { file: string; eventOffset: number }; maxEvents?: number })
-        : collectCodexCostEvents(payload as { cursor?: { file: string; eventOffset: number }; maxEvents?: number });
+        ? collectPiCostEvents({ ...(payload as { maxEvents?: number }), onBatch: emitProgress })
+        : collectCodexCostEvents({ ...(payload as { maxEvents?: number }), onBatch: emitProgress });
   }
 }
 
@@ -169,7 +181,13 @@ function drainQueue(): void {
   }
 }
 
-parentPort?.on('message', (message: DashboardDbRequest) => {
+parentPort?.on('message', (message: DashboardDbRequest | DashboardDbAck) => {
+  if ('ack' in message) {
+    const resolve = progressAcks.get(`${message.id}:${message.ack}`);
+    progressAcks.delete(`${message.id}:${message.ack}`);
+    resolve?.();
+    return;
+  }
   queue.push(message);
   drainQueue();
 });

--- a/src/lib/costs/codex-collector.ts
+++ b/src/lib/costs/codex-collector.ts
@@ -31,6 +31,7 @@ type CostReconcileExtraRoot =
   | { kind: 'ohmypi-legacy-agents'; root: string };
 
 type SkippedCostSession = { file: string; reason: string };
+export type CostCollectCursor = { file: string; eventOffset: number };
 
 function walkJsonl(dir: string): string[] {
   if (!existsSync(dir)) return [];
@@ -53,6 +54,8 @@ function inferIssueFromPath(path: string | undefined): IssueId | null {
 export async function collectCodexCostEvents(opts: {
   extraRoots?: string[];
   extraRootSpecs?: CostReconcileExtraRoot[];
+  cursor?: CostCollectCursor;
+  maxEvents?: number;
 } = {}) {
   const agentsDir = join(getOverdeckHome(), 'agents');
   const names = existsSync(agentsDir)
@@ -70,13 +73,21 @@ export async function collectCodexCostEvents(opts: {
   const errors: string[] = [];
   let scanned = 0;
   let cacheSkipped = 0;
-  for (const root of roots) for (const file of walkJsonl(root.root)) {
-    scanned++;
+  const candidates = roots.flatMap(root => walkJsonl(root.root).map(file => ({ file, root })))
+    .sort((a, b) => a.file.localeCompare(b.file));
+  const maxEvents = opts.maxEvents ?? Number.POSITIVE_INFINITY;
+  let nextCursor: CostCollectCursor | null = null;
+  let done = true;
+  outer: for (const { file, root } of candidates) {
+    if (opts.cursor && file < opts.cursor.file) continue;
+    const eventOffset = opts.cursor?.file === file ? opts.cursor.eventOffset : 0;
+    if (eventOffset === 0) scanned++;
     const stat = statSync(file);
-    if (lookupSkipVerdict(file, stat.mtimeMs, stat.size)) { cacheSkipped++; continue; }
+    if (eventOffset === 0 && lookupSkipVerdict(file, stat.mtimeMs, stat.size)) { cacheSkipped++; continue; }
     let parsed;
     try { parsed = parseCodexSessionCostEventsSync(file); }
     catch (cause) { errors.push(`${file}: ${cause instanceof Error ? cause.message : String(cause)}`); continue; }
+    if (eventOffset >= parsed.length && eventOffset > 0) continue;
     if (parsed.length === 0) {
       skipped.push({ file, reason: 'no-usage' });
       verdicts.push({ path: file, mtimeMs: stat.mtimeMs, size: stat.size, verdict: 'no-usage' });
@@ -86,11 +97,23 @@ export async function collectCodexCostEvents(opts: {
     if (unknown) skipped.push({ file, reason: 'unknown-model' });
     const session = root.inferIssueFromCwd ? parseCodexSessionSync(file) : null;
     const issueId = root.inferIssueFromCwd ? inferIssueFromPath(session?.cwd) ?? 'UNKNOWN' as IssueId : root.issueId;
-    events.push(...parsed.map(usage => ({ ts: new Date(usage.timestamp), issueId, agentId: root.agentName,
+    const remaining = maxEvents - events.length;
+    const selected = parsed.slice(eventOffset, eventOffset + remaining);
+    events.push(...selected.map(usage => ({ ts: new Date(usage.timestamp), issueId, agentId: root.agentName,
       sessionId: usage.sessionId, sessionType: 'codex', provider: usage.provider, model: usage.model,
       input: usage.input, output: usage.output, cacheRead: usage.cacheRead, cacheWrite: usage.cacheWrite,
       cost: usage.cost, requestId: usage.requestId, sourceFile: file })));
+    if (eventOffset + selected.length < parsed.length) {
+      nextCursor = { file, eventOffset: eventOffset + selected.length };
+      done = false;
+      break outer;
+    }
     verdicts.push({ path: file, mtimeMs: stat.mtimeMs, size: stat.size, verdict: unknown ? 'unknown-model' : 'imported' });
+    if (events.length >= maxEvents) {
+      nextCursor = { file, eventOffset: parsed.length };
+      done = candidates.at(-1)?.file === file;
+      break outer;
+    }
   }
-  return { events, verdicts, stats: { scanned, cacheSkipped }, skipped, errors };
+  return { events, verdicts, stats: { scanned, cacheSkipped }, skipped, errors, nextCursor, done };
 }

--- a/src/lib/costs/codex-collector.ts
+++ b/src/lib/costs/codex-collector.ts
@@ -31,7 +31,7 @@ type CostReconcileExtraRoot =
   | { kind: 'ohmypi-legacy-agents'; root: string };
 
 type SkippedCostSession = { file: string; reason: string };
-export type CostCollectCursor = { file: string; eventOffset: number };
+export type CodexCollectBatch = { events: CollectedCostEvent[]; verdicts: SkipVerdictEntry[] };
 
 function walkJsonl(dir: string): string[] {
   if (!existsSync(dir)) return [];
@@ -54,8 +54,8 @@ function inferIssueFromPath(path: string | undefined): IssueId | null {
 export async function collectCodexCostEvents(opts: {
   extraRoots?: string[];
   extraRootSpecs?: CostReconcileExtraRoot[];
-  cursor?: CostCollectCursor;
   maxEvents?: number;
+  onBatch?: (batch: CodexCollectBatch) => Promise<void>;
 } = {}) {
   const agentsDir = join(getOverdeckHome(), 'agents');
   const names = existsSync(agentsDir)
@@ -67,8 +67,8 @@ export async function collectCodexCostEvents(opts: {
     roots.push({ root: extra.root, agentName: 'codex-global', issueId: null, inferIssueFromCwd: true });
   }
 
-  const events: CollectedCostEvent[] = [];
-  const verdicts: SkipVerdictEntry[] = [];
+  let events: CollectedCostEvent[] = [];
+  let verdicts: SkipVerdictEntry[] = [];
   const skipped: SkippedCostSession[] = [];
   const errors: string[] = [];
   let scanned = 0;
@@ -76,44 +76,40 @@ export async function collectCodexCostEvents(opts: {
   const candidates = roots.flatMap(root => walkJsonl(root.root).map(file => ({ file, root })))
     .sort((a, b) => a.file.localeCompare(b.file));
   const maxEvents = opts.maxEvents ?? Number.POSITIVE_INFINITY;
-  let nextCursor: CostCollectCursor | null = null;
-  let done = true;
-  outer: for (const { file, root } of candidates) {
-    if (opts.cursor && file < opts.cursor.file) continue;
-    const eventOffset = opts.cursor?.file === file ? opts.cursor.eventOffset : 0;
-    if (eventOffset === 0) scanned++;
+  const flush = async () => {
+    if (!opts.onBatch || (events.length === 0 && verdicts.length === 0)) return;
+    const batch = { events, verdicts };
+    events = [];
+    verdicts = [];
+    await opts.onBatch(batch);
+  };
+  for (const { file, root } of candidates) {
+    scanned++;
     const stat = statSync(file);
-    if (eventOffset === 0 && lookupSkipVerdict(file, stat.mtimeMs, stat.size)) { cacheSkipped++; continue; }
+    if (lookupSkipVerdict(file, stat.mtimeMs, stat.size)) { cacheSkipped++; continue; }
     let parsed;
     try { parsed = parseCodexSessionCostEventsSync(file); }
     catch (cause) { errors.push(`${file}: ${cause instanceof Error ? cause.message : String(cause)}`); continue; }
-    if (eventOffset >= parsed.length && eventOffset > 0) continue;
     if (parsed.length === 0) {
       skipped.push({ file, reason: 'no-usage' });
       verdicts.push({ path: file, mtimeMs: stat.mtimeMs, size: stat.size, verdict: 'no-usage' });
+      await flush();
       continue;
     }
     const unknown = parsed.some(event => event.model === 'unknown');
     if (unknown) skipped.push({ file, reason: 'unknown-model' });
     const session = root.inferIssueFromCwd ? parseCodexSessionSync(file) : null;
     const issueId = root.inferIssueFromCwd ? inferIssueFromPath(session?.cwd) ?? 'UNKNOWN' as IssueId : root.issueId;
-    const remaining = maxEvents - events.length;
-    const selected = parsed.slice(eventOffset, eventOffset + remaining);
-    events.push(...selected.map(usage => ({ ts: new Date(usage.timestamp), issueId, agentId: root.agentName,
-      sessionId: usage.sessionId, sessionType: 'codex', provider: usage.provider, model: usage.model,
-      input: usage.input, output: usage.output, cacheRead: usage.cacheRead, cacheWrite: usage.cacheWrite,
-      cost: usage.cost, requestId: usage.requestId, sourceFile: file })));
-    if (eventOffset + selected.length < parsed.length) {
-      nextCursor = { file, eventOffset: eventOffset + selected.length };
-      done = false;
-      break outer;
+    for (const usage of parsed) {
+      events.push({ ts: new Date(usage.timestamp), issueId, agentId: root.agentName,
+        sessionId: usage.sessionId, sessionType: 'codex', provider: usage.provider, model: usage.model,
+        input: usage.input, output: usage.output, cacheRead: usage.cacheRead, cacheWrite: usage.cacheWrite,
+        cost: usage.cost, requestId: usage.requestId, sourceFile: file });
+      if (events.length >= maxEvents) await flush();
     }
     verdicts.push({ path: file, mtimeMs: stat.mtimeMs, size: stat.size, verdict: unknown ? 'unknown-model' : 'imported' });
-    if (events.length >= maxEvents) {
-      nextCursor = { file, eventOffset: parsed.length };
-      done = candidates.at(-1)?.file === file;
-      break outer;
-    }
+    await flush();
   }
-  return { events, verdicts, stats: { scanned, cacheSkipped }, skipped, errors, nextCursor, done };
+  await flush();
+  return { events, verdicts, stats: { scanned, cacheSkipped }, skipped, errors };
 }

--- a/src/lib/costs/codex-collector.ts
+++ b/src/lib/costs/codex-collector.ts
@@ -1,0 +1,73 @@
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { parseCodexSessionCostEventsSync, parseCodexSessionSync } from '../cost-parsers/codex-parser.js';
+import { getOverdeckHome } from '../paths.js';
+import type { CostEvent, CostReconcileExtraRoot, SkippedCostSession } from '../overdeck/cost.js';
+import type { IssueId } from '../overdeck/issues.js';
+import { lookupSkipVerdict, type SkipVerdict } from './skip-cache.js';
+
+export type SkipVerdictEntry = { path: string; mtimeMs: number; size: number; verdict: SkipVerdict };
+
+function walkJsonl(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const full = join(dir, entry.name);
+    return entry.isDirectory() ? walkJsonl(full) : entry.name.endsWith('.jsonl') ? [full] : [];
+  });
+}
+
+function issueIdFromAgentName(name: string): IssueId | null {
+  const match = name.match(/(?:agent|planning)-((?:[a-z]+-)?\d+)/i);
+  return match?.[1] ? match[1].toUpperCase() as IssueId : null;
+}
+
+function inferIssueFromPath(path: string | undefined): IssueId | null {
+  const match = path?.match(/(?:feature[-/]|workspaces\/feature-)([a-z]+-\d+)/i);
+  return match?.[1] ? match[1].toUpperCase() as IssueId : null;
+}
+
+export async function collectCodexCostEvents(opts: {
+  extraRoots?: string[];
+  extraRootSpecs?: CostReconcileExtraRoot[];
+} = {}) {
+  const agentsDir = join(getOverdeckHome(), 'agents');
+  const names = existsSync(agentsDir)
+    ? readdirSync(agentsDir, { withFileTypes: true }).filter(e => e.isDirectory()).map(e => e.name) : [];
+  const roots = names.map(agentName => ({ root: join(agentsDir, agentName, 'codex-home', 'sessions'),
+    agentName, issueId: issueIdFromAgentName(agentName), inferIssueFromCwd: false }));
+  for (const root of opts.extraRoots ?? []) roots.push({ root, agentName: 'codex-global', issueId: null, inferIssueFromCwd: true });
+  for (const extra of opts.extraRootSpecs ?? []) if (extra.kind === 'codex-global') {
+    roots.push({ root: extra.root, agentName: 'codex-global', issueId: null, inferIssueFromCwd: true });
+  }
+
+  const events: CostEvent[] = [];
+  const verdicts: SkipVerdictEntry[] = [];
+  const skipped: SkippedCostSession[] = [];
+  const errors: string[] = [];
+  let scanned = 0;
+  let cacheSkipped = 0;
+  for (const root of roots) for (const file of walkJsonl(root.root)) {
+    scanned++;
+    const stat = statSync(file);
+    if (lookupSkipVerdict(file, stat.mtimeMs, stat.size)) { cacheSkipped++; continue; }
+    let parsed;
+    try { parsed = parseCodexSessionCostEventsSync(file); }
+    catch (cause) { errors.push(`${file}: ${cause instanceof Error ? cause.message : String(cause)}`); continue; }
+    if (parsed.length === 0) {
+      skipped.push({ file, reason: 'no-usage' });
+      verdicts.push({ path: file, mtimeMs: stat.mtimeMs, size: stat.size, verdict: 'no-usage' });
+      continue;
+    }
+    const unknown = parsed.some(event => event.model === 'unknown');
+    if (unknown) skipped.push({ file, reason: 'unknown-model' });
+    const session = root.inferIssueFromCwd ? parseCodexSessionSync(file) : null;
+    const issueId = root.inferIssueFromCwd ? inferIssueFromPath(session?.cwd) ?? 'UNKNOWN' as IssueId : root.issueId;
+    events.push(...parsed.map(usage => ({ ts: new Date(usage.timestamp), issueId, agentId: root.agentName,
+      sessionId: usage.sessionId, sessionType: 'codex', provider: usage.provider, model: usage.model,
+      input: usage.input, output: usage.output, cacheRead: usage.cacheRead, cacheWrite: usage.cacheWrite,
+      cost: usage.cost, requestId: usage.requestId, sourceFile: file })));
+    verdicts.push({ path: file, mtimeMs: stat.mtimeMs, size: stat.size, verdict: unknown ? 'unknown-model' : 'imported' });
+  }
+  return { events, verdicts, stats: { scanned, cacheSkipped }, skipped, errors };
+}

--- a/src/lib/costs/codex-collector.ts
+++ b/src/lib/costs/codex-collector.ts
@@ -3,11 +3,34 @@ import { join } from 'node:path';
 
 import { parseCodexSessionCostEventsSync, parseCodexSessionSync } from '../cost-parsers/codex-parser.js';
 import { getOverdeckHome } from '../paths.js';
-import type { CostEvent, CostReconcileExtraRoot, SkippedCostSession } from '../overdeck/cost.js';
 import type { IssueId } from '../overdeck/issues.js';
 import { lookupSkipVerdict, type SkipVerdict } from './skip-cache.js';
 
 export type SkipVerdictEntry = { path: string; mtimeMs: number; size: number; verdict: SkipVerdict };
+
+type CollectedCostEvent = {
+  ts: Date;
+  issueId: IssueId | null;
+  agentId: string | null;
+  sessionId: string | null;
+  sessionType: string | null;
+  provider: string | null;
+  model: string | null;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  cost: number;
+  requestId: string | null;
+  sourceFile: string | null;
+};
+
+type CostReconcileExtraRoot =
+  | { kind: 'codex-global'; root: string }
+  | { kind: 'ohmypi-global'; root: string }
+  | { kind: 'ohmypi-legacy-agents'; root: string };
+
+type SkippedCostSession = { file: string; reason: string };
 
 function walkJsonl(dir: string): string[] {
   if (!existsSync(dir)) return [];
@@ -41,7 +64,7 @@ export async function collectCodexCostEvents(opts: {
     roots.push({ root: extra.root, agentName: 'codex-global', issueId: null, inferIssueFromCwd: true });
   }
 
-  const events: CostEvent[] = [];
+  const events: CollectedCostEvent[] = [];
   const verdicts: SkipVerdictEntry[] = [];
   const skipped: SkippedCostSession[] = [];
   const errors: string[] = [];

--- a/src/lib/costs/reconciler.ts
+++ b/src/lib/costs/reconciler.ts
@@ -52,9 +52,8 @@ export type PiCollectResult = {
   verdicts: Array<{ path: string; mtimeMs: number; size: number; verdict: 'imported' | 'no-usage' }>;
   stats: { scanned: number; cacheSkipped: number; sessionsWithData: number };
   errors: Array<{ path: string; error: string }>;
-  nextCursor?: { file: string; eventOffset: number } | null;
-  done?: boolean;
 };
+export type PiCollectBatch = Pick<PiCollectResult, 'events' | 'verdicts'>;
 
 interface SessionMapping {
   agentId: string;
@@ -488,8 +487,8 @@ function findPiTranscriptFiles(agentDir: string): TranscriptFileStat[] {
  * extension emits null usage or the wrong model label.
  */
 export async function collectPiCostEvents(opts: {
-  cursor?: { file: string; eventOffset: number };
   maxEvents?: number;
+  onBatch?: (batch: PiCollectBatch) => Promise<void>;
 } = {}): Promise<PiCollectResult> {
   const result: PiCollectResult = {
     events: [], verdicts: [], stats: { scanned: 0, cacheSkipped: 0, sessionsWithData: 0 }, errors: [],
@@ -535,41 +534,37 @@ export async function collectPiCostEvents(opts: {
 
   candidates.sort((a, b) => a.path.localeCompare(b.path));
   const maxEvents = opts.maxEvents ?? Number.POSITIVE_INFINITY;
-  result.done = true;
+  const flush = async () => {
+    if (!opts.onBatch || (result.events.length === 0 && result.verdicts.length === 0)) return;
+    const batch = { events: result.events, verdicts: result.verdicts };
+    result.events = [];
+    result.verdicts = [];
+    await opts.onBatch(batch);
+  };
   for (const transcript of candidates) {
-    if (opts.cursor && transcript.path < opts.cursor.file) continue;
     const transcriptPath = transcript.path;
-    const eventOffset = opts.cursor?.file === transcriptPath ? opts.cursor.eventOffset : 0;
     const sessionId = basename(transcriptPath, '.jsonl');
     const resolvedIssueId = transcript.issueId ?? resolveUnmappedSessionIssueId({ sessionId, agentId: transcript.agentDirName });
-    if (eventOffset === 0) result.stats.scanned++;
-    if (eventOffset === 0 && lookupSkipVerdict(transcriptPath, transcript.mtimeMs, transcript.size)) {
+    result.stats.scanned++;
+    if (lookupSkipVerdict(transcriptPath, transcript.mtimeMs, transcript.size)) {
       result.stats.cacheSkipped++;
       continue;
     }
     try {
       const content = readFileSync(transcriptPath, 'utf-8');
       const events = extractPiCostEvents(content, transcript.agentDirName, resolvedIssueId, transcript.sessionType, sessionId);
-      if (eventOffset >= events.length && eventOffset > 0) continue;
       if (events.length === 0) {
         result.verdicts.push({ path: transcriptPath, mtimeMs: transcript.mtimeMs, size: transcript.size, verdict: 'no-usage' });
+        await flush();
         continue;
       }
       result.stats.sessionsWithData++;
-      const remaining = maxEvents - result.events.length;
-      const selected = events.slice(eventOffset, eventOffset + remaining);
-      result.events.push(...selected.map(event => ({ event, sourceFile: `reconciler:${transcriptPath}` })));
-      if (eventOffset + selected.length < events.length) {
-        result.nextCursor = { file: transcriptPath, eventOffset: eventOffset + selected.length };
-        result.done = false;
-        break;
+      for (const event of events) {
+        result.events.push({ event, sourceFile: `reconciler:${transcriptPath}` });
+        if (result.events.length >= maxEvents) await flush();
       }
       result.verdicts.push({ path: transcriptPath, mtimeMs: transcript.mtimeMs, size: transcript.size, verdict: 'imported' });
-      if (result.events.length >= maxEvents) {
-        result.nextCursor = { file: transcriptPath, eventOffset: events.length };
-        result.done = candidates.at(-1)?.path === transcriptPath;
-        break;
-      }
+      await flush();
     } catch (err) {
       result.errors.push({
         path: transcriptPath,
@@ -577,6 +572,8 @@ export async function collectPiCostEvents(opts: {
       });
     }
   }
+
+  await flush();
 
   return result;
 }

--- a/src/lib/costs/reconciler.ts
+++ b/src/lib/costs/reconciler.ts
@@ -52,6 +52,8 @@ export type PiCollectResult = {
   verdicts: Array<{ path: string; mtimeMs: number; size: number; verdict: 'imported' | 'no-usage' }>;
   stats: { scanned: number; cacheSkipped: number; sessionsWithData: number };
   errors: Array<{ path: string; error: string }>;
+  nextCursor?: { file: string; eventOffset: number } | null;
+  done?: boolean;
 };
 
 interface SessionMapping {
@@ -450,24 +452,19 @@ export function extractPiCostEvents(
  */
 type TranscriptFileStat = { path: string; mtimeMs: number; size: number };
 
-function findPiTranscriptFiles(agentDir: string): { files: TranscriptFileStat[]; cacheSkipped: number } {
+function findPiTranscriptFiles(agentDir: string): TranscriptFileStat[] {
   let files: string[];
   try {
     files = readdirSync(agentDir).filter((f) => f.endsWith('.jsonl'));
   } catch {
-    return { files: [], cacheSkipped: 0 };
+    return [];
   }
   const transcripts: TranscriptFileStat[] = [];
-  let cacheSkipped = 0;
   for (const f of files) {
     if (f === 'activity.jsonl' || f === 'cost-events.jsonl' || f === 'pending-events.jsonl') continue;
     const full = join(agentDir, f);
     try {
       const stat = statSync(full);
-      if (lookupSkipVerdict(full, stat.mtimeMs, stat.size)) {
-        cacheSkipped++;
-        continue;
-      }
       const fd = openSync(full, 'r');
       const buf = Buffer.alloc(128);
       const bytesRead = readSync(fd, buf, 0, 128, 0);
@@ -480,7 +477,7 @@ function findPiTranscriptFiles(agentDir: string): { files: TranscriptFileStat[];
       // skip unreadable
     }
   }
-  return { files: transcripts, cacheSkipped };
+  return transcripts;
 }
 
 /**
@@ -490,7 +487,10 @@ function findPiTranscriptFiles(agentDir: string): { files: TranscriptFileStat[];
  * Independent of the pi extension hook, so it captures cost even when the
  * extension emits null usage or the wrong model label.
  */
-export async function collectPiCostEvents(): Promise<PiCollectResult> {
+export async function collectPiCostEvents(opts: {
+  cursor?: { file: string; eventOffset: number };
+  maxEvents?: number;
+} = {}): Promise<PiCollectResult> {
   const result: PiCollectResult = {
     events: [], verdicts: [], stats: { scanned: 0, cacheSkipped: 0, sessionsWithData: 0 }, errors: [],
   };
@@ -504,6 +504,11 @@ export async function collectPiCostEvents(): Promise<PiCollectResult> {
     return result;
   }
 
+  const candidates: Array<TranscriptFileStat & {
+    agentDirName: string;
+    issueId: string | null;
+    sessionType: string;
+  }> = [];
   for (const agentDirName of agentDirs) {
     const agentPath = join(agentsDir, agentDirName);
 
@@ -523,30 +528,53 @@ export async function collectPiCostEvents(): Promise<PiCollectResult> {
     }
     if (agentDirName.startsWith('planning-')) sessionType = 'planning';
 
-    const transcripts = findPiTranscriptFiles(agentPath);
-    result.stats.cacheSkipped += transcripts.cacheSkipped;
-    result.stats.scanned += transcripts.cacheSkipped;
-    for (const transcript of transcripts.files) {
-      const transcriptPath = transcript.path;
-      const sessionId = basename(transcriptPath, '.jsonl');
-      const resolvedIssueId = issueId ?? resolveUnmappedSessionIssueId({ sessionId, agentId: agentDirName });
-      result.stats.scanned++;
-      try {
-        const content = readFileSync(transcriptPath, 'utf-8');
-        const events = extractPiCostEvents(content, agentDirName, resolvedIssueId, sessionType, sessionId);
-        if (events.length === 0) {
-          result.verdicts.push({ path: transcriptPath, mtimeMs: transcript.mtimeMs, size: transcript.size, verdict: 'no-usage' });
-          continue;
-        }
-        result.stats.sessionsWithData++;
-        result.events.push(...events.map(event => ({ event, sourceFile: `reconciler:${transcriptPath}` })));
-        result.verdicts.push({ path: transcriptPath, mtimeMs: transcript.mtimeMs, size: transcript.size, verdict: 'imported' });
-      } catch (err) {
-        result.errors.push({
-          path: transcriptPath,
-          error: err instanceof Error ? err.message : String(err),
-        });
+    candidates.push(...findPiTranscriptFiles(agentPath).map(transcript => ({
+      ...transcript, agentDirName, issueId, sessionType,
+    })));
+  }
+
+  candidates.sort((a, b) => a.path.localeCompare(b.path));
+  const maxEvents = opts.maxEvents ?? Number.POSITIVE_INFINITY;
+  result.done = true;
+  for (const transcript of candidates) {
+    if (opts.cursor && transcript.path < opts.cursor.file) continue;
+    const transcriptPath = transcript.path;
+    const eventOffset = opts.cursor?.file === transcriptPath ? opts.cursor.eventOffset : 0;
+    const sessionId = basename(transcriptPath, '.jsonl');
+    const resolvedIssueId = transcript.issueId ?? resolveUnmappedSessionIssueId({ sessionId, agentId: transcript.agentDirName });
+    if (eventOffset === 0) result.stats.scanned++;
+    if (eventOffset === 0 && lookupSkipVerdict(transcriptPath, transcript.mtimeMs, transcript.size)) {
+      result.stats.cacheSkipped++;
+      continue;
+    }
+    try {
+      const content = readFileSync(transcriptPath, 'utf-8');
+      const events = extractPiCostEvents(content, transcript.agentDirName, resolvedIssueId, transcript.sessionType, sessionId);
+      if (eventOffset >= events.length && eventOffset > 0) continue;
+      if (events.length === 0) {
+        result.verdicts.push({ path: transcriptPath, mtimeMs: transcript.mtimeMs, size: transcript.size, verdict: 'no-usage' });
+        continue;
       }
+      result.stats.sessionsWithData++;
+      const remaining = maxEvents - result.events.length;
+      const selected = events.slice(eventOffset, eventOffset + remaining);
+      result.events.push(...selected.map(event => ({ event, sourceFile: `reconciler:${transcriptPath}` })));
+      if (eventOffset + selected.length < events.length) {
+        result.nextCursor = { file: transcriptPath, eventOffset: eventOffset + selected.length };
+        result.done = false;
+        break;
+      }
+      result.verdicts.push({ path: transcriptPath, mtimeMs: transcript.mtimeMs, size: transcript.size, verdict: 'imported' });
+      if (result.events.length >= maxEvents) {
+        result.nextCursor = { file: transcriptPath, eventOffset: events.length };
+        result.done = candidates.at(-1)?.path === transcriptPath;
+        break;
+      }
+    } catch (err) {
+      result.errors.push({
+        path: transcriptPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 

--- a/src/lib/costs/reconciler.ts
+++ b/src/lib/costs/reconciler.ts
@@ -46,6 +46,14 @@ export interface ReconcileResult {
   latestEventTs: string | null;
 }
 
+export type PiCollectedEvent = { event: CostEvent; sourceFile: string };
+export type PiCollectResult = {
+  events: PiCollectedEvent[];
+  verdicts: Array<{ path: string; mtimeMs: number; size: number; verdict: 'imported' | 'no-usage' }>;
+  stats: { scanned: number; cacheSkipped: number; sessionsWithData: number };
+  errors: Array<{ path: string; error: string }>;
+};
+
 interface SessionMapping {
   agentId: string;
   issueId: string | null;
@@ -482,18 +490,10 @@ function findPiTranscriptFiles(agentDir: string): { files: TranscriptFileStat[];
  * Independent of the pi extension hook, so it captures cost even when the
  * extension emits null usage or the wrong model label.
  */
-export async function reconcilePiTranscripts(): Promise<ReconcileResult> {
-  const result: ReconcileResult = {
-    sessionsScanned: 0,
-    cacheSkipped: 0,
-    sessionsWithNewData: 0,
-    eventsImported: 0,
-    duplicatesSkipped: 0,
-    errors: [],
-    earliestEventTs: null,
-    latestEventTs: null,
+export async function collectPiCostEvents(): Promise<PiCollectResult> {
+  const result: PiCollectResult = {
+    events: [], verdicts: [], stats: { scanned: 0, cacheSkipped: 0, sessionsWithData: 0 }, errors: [],
   };
-
   const agentsDir = getAgentsDir();
   if (!existsSync(agentsDir)) return result;
 
@@ -524,26 +524,23 @@ export async function reconcilePiTranscripts(): Promise<ReconcileResult> {
     if (agentDirName.startsWith('planning-')) sessionType = 'planning';
 
     const transcripts = findPiTranscriptFiles(agentPath);
-    result.cacheSkipped += transcripts.cacheSkipped;
-    result.sessionsScanned += transcripts.cacheSkipped;
+    result.stats.cacheSkipped += transcripts.cacheSkipped;
+    result.stats.scanned += transcripts.cacheSkipped;
     for (const transcript of transcripts.files) {
       const transcriptPath = transcript.path;
       const sessionId = basename(transcriptPath, '.jsonl');
       const resolvedIssueId = issueId ?? resolveUnmappedSessionIssueId({ sessionId, agentId: agentDirName });
-      result.sessionsScanned++;
+      result.stats.scanned++;
       try {
         const content = readFileSync(transcriptPath, 'utf-8');
         const events = extractPiCostEvents(content, agentDirName, resolvedIssueId, sessionType, sessionId);
         if (events.length === 0) {
-          recordSkipVerdict(transcriptPath, transcript.mtimeMs, transcript.size, 'no-usage');
+          result.verdicts.push({ path: transcriptPath, mtimeMs: transcript.mtimeMs, size: transcript.size, verdict: 'no-usage' });
           continue;
         }
-        result.sessionsWithNewData++;
-        const { inserted, duplicates, earliestEventTs, latestEventTs } = await recordCostEventsThroughOverdeck(events, `reconciler:${transcriptPath}`);
-        result.eventsImported += inserted;
-        result.duplicatesSkipped += duplicates;
-        mergeCoverage(result, { earliestEventTs, latestEventTs });
-        recordSkipVerdict(transcriptPath, transcript.mtimeMs, transcript.size, 'imported');
+        result.stats.sessionsWithData++;
+        result.events.push(...events.map(event => ({ event, sourceFile: `reconciler:${transcriptPath}` })));
+        result.verdicts.push({ path: transcriptPath, mtimeMs: transcript.mtimeMs, size: transcript.size, verdict: 'imported' });
       } catch (err) {
         result.errors.push({
           path: transcriptPath,
@@ -553,6 +550,25 @@ export async function reconcilePiTranscripts(): Promise<ReconcileResult> {
     }
   }
 
+  return result;
+}
+
+export async function reconcilePiTranscripts(): Promise<ReconcileResult> {
+  const collected = await collectPiCostEvents();
+  const result: ReconcileResult = {
+    sessionsScanned: collected.stats.scanned, cacheSkipped: collected.stats.cacheSkipped,
+    sessionsWithNewData: collected.stats.sessionsWithData, eventsImported: 0, duplicatesSkipped: 0,
+    errors: collected.errors, earliestEventTs: null, latestEventTs: null,
+  };
+  for (const { event, sourceFile } of collected.events) {
+    const recorded = await recordCostEventsThroughOverdeck([event], sourceFile);
+    result.eventsImported += recorded.inserted;
+    result.duplicatesSkipped += recorded.duplicates;
+    mergeCoverage(result, recorded);
+  }
+  for (const verdict of collected.verdicts) {
+    recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
+  }
   return result;
 }
 
@@ -575,7 +591,7 @@ function toOverdeckCostEvent(event: CostEvent, sourceFile: string): OverdeckCost
   };
 }
 
-async function recordCostEventsThroughOverdeck(
+export async function recordCostEventsThroughOverdeck(
   events: CostEvent[],
   sourceFile: string,
   opts: { dryRun?: boolean } = {},

--- a/src/lib/costs/reconciler.ts
+++ b/src/lib/costs/reconciler.ts
@@ -20,7 +20,7 @@
  * - Catches everything: scans all transcript files regardless of source
  */
 
-import { readFileSync, existsSync, readdirSync, openSync, readSync, fstatSync, closeSync } from 'fs';
+import { readFileSync, existsSync, readdirSync, openSync, readSync, fstatSync, closeSync, statSync } from 'fs';
 import { join, basename } from 'path';
 import { homedir } from 'os';
 import { Effect } from 'effect';
@@ -31,11 +31,13 @@ import { findConversationForCostSessionSync } from '../overdeck/conversations.js
 import type { IssueId } from '../overdeck/issues.js';
 import { classifySessionBucket, type ConversationSessionLookup } from './attribution.js';
 import type { CostEvent } from './events.js';
+import { lookupSkipVerdict, recordSkipVerdict } from './skip-cache.js';
 
 // ============== Types ==============
 
 export interface ReconcileResult {
   sessionsScanned: number;
+  cacheSkipped: number;
   sessionsWithNewData: number;
   eventsImported: number;
   duplicatesSkipped: number;
@@ -438,29 +440,39 @@ export function extractPiCostEvents(
  * `{"type":"session","version":3,...}` header; we detect that and skip the
  * sibling non-transcripts (activity.jsonl, cost-events.jsonl, pending-events).
  */
-function findPiTranscriptFiles(agentDir: string): string[] {
+type TranscriptFileStat = { path: string; mtimeMs: number; size: number };
+
+function findPiTranscriptFiles(agentDir: string): { files: TranscriptFileStat[]; cacheSkipped: number } {
   let files: string[];
   try {
     files = readdirSync(agentDir).filter((f) => f.endsWith('.jsonl'));
   } catch {
-    return [];
+    return { files: [], cacheSkipped: 0 };
   }
-  const transcripts: string[] = [];
+  const transcripts: TranscriptFileStat[] = [];
+  let cacheSkipped = 0;
   for (const f of files) {
     if (f === 'activity.jsonl' || f === 'cost-events.jsonl' || f === 'pending-events.jsonl') continue;
     const full = join(agentDir, f);
     try {
+      const stat = statSync(full);
+      if (lookupSkipVerdict(full, stat.mtimeMs, stat.size)) {
+        cacheSkipped++;
+        continue;
+      }
       const fd = openSync(full, 'r');
       const buf = Buffer.alloc(128);
       const bytesRead = readSync(fd, buf, 0, 128, 0);
       closeSync(fd);
       const head = buf.toString('utf-8', 0, bytesRead);
-      if (/"type"\s*:\s*"session"/.test(head)) transcripts.push(full);
+      if (/"type"\s*:\s*"session"/.test(head)) {
+        transcripts.push({ path: full, mtimeMs: stat.mtimeMs, size: stat.size });
+      }
     } catch {
       // skip unreadable
     }
   }
-  return transcripts;
+  return { files: transcripts, cacheSkipped };
 }
 
 /**
@@ -473,6 +485,7 @@ function findPiTranscriptFiles(agentDir: string): string[] {
 export async function reconcilePiTranscripts(): Promise<ReconcileResult> {
   const result: ReconcileResult = {
     sessionsScanned: 0,
+    cacheSkipped: 0,
     sessionsWithNewData: 0,
     eventsImported: 0,
     duplicatesSkipped: 0,
@@ -511,19 +524,26 @@ export async function reconcilePiTranscripts(): Promise<ReconcileResult> {
     if (agentDirName.startsWith('planning-')) sessionType = 'planning';
 
     const transcripts = findPiTranscriptFiles(agentPath);
-    for (const transcriptPath of transcripts) {
+    result.cacheSkipped += transcripts.cacheSkipped;
+    result.sessionsScanned += transcripts.cacheSkipped;
+    for (const transcript of transcripts.files) {
+      const transcriptPath = transcript.path;
       const sessionId = basename(transcriptPath, '.jsonl');
       const resolvedIssueId = issueId ?? resolveUnmappedSessionIssueId({ sessionId, agentId: agentDirName });
       result.sessionsScanned++;
       try {
         const content = readFileSync(transcriptPath, 'utf-8');
         const events = extractPiCostEvents(content, agentDirName, resolvedIssueId, sessionType, sessionId);
-        if (events.length === 0) continue;
+        if (events.length === 0) {
+          recordSkipVerdict(transcriptPath, transcript.mtimeMs, transcript.size, 'no-usage');
+          continue;
+        }
         result.sessionsWithNewData++;
         const { inserted, duplicates, earliestEventTs, latestEventTs } = await recordCostEventsThroughOverdeck(events, `reconciler:${transcriptPath}`);
         result.eventsImported += inserted;
         result.duplicatesSkipped += duplicates;
         mergeCoverage(result, { earliestEventTs, latestEventTs });
+        recordSkipVerdict(transcriptPath, transcript.mtimeMs, transcript.size, 'imported');
       } catch (err) {
         result.errors.push({
           path: transcriptPath,
@@ -597,6 +617,7 @@ function mergeCoverage(
 async function reconcilePromise(opts: { dryRun?: boolean; includePi?: boolean } = {}): Promise<ReconcileResult> {
   const result: ReconcileResult = {
     sessionsScanned: 0,
+    cacheSkipped: 0,
     sessionsWithNewData: 0,
     eventsImported: 0,
     duplicatesSkipped: 0,
@@ -647,6 +668,11 @@ async function reconcilePromise(opts: { dryRun?: boolean; includePi?: boolean } 
       result.sessionsScanned++;
 
       try {
+        const transcriptStat = statSync(transcriptPath);
+        if (lookupSkipVerdict(transcriptPath, transcriptStat.mtimeMs, transcriptStat.size)) {
+          result.cacheSkipped++;
+          continue;
+        }
         // Look up agent mapping for this session
         const mapping = sessionIndex.get(sessionId);
         const agentId = mapping?.agentId || 'unattributed';
@@ -662,6 +688,7 @@ async function reconcilePromise(opts: { dryRun?: boolean; includePi?: boolean } 
           if (!opts.dryRun && readResult && readResult.newSize > lastOffset) {
             saveSessionOffset(sessionId, readResult.newSize, 0, agentId, issueId, transcriptPath);
           }
+          if (!opts.dryRun) recordSkipVerdict(transcriptPath, transcriptStat.mtimeMs, transcriptStat.size, 'no-usage');
           continue;
         }
 
@@ -684,6 +711,7 @@ async function reconcilePromise(opts: { dryRun?: boolean; includePi?: boolean } 
 
         if (!opts.dryRun) {
           saveSessionOffset(sessionId, readResult.newSize, inserted, agentId, issueId, transcriptPath);
+          recordSkipVerdict(transcriptPath, transcriptStat.mtimeMs, transcriptStat.size, 'imported');
         }
       } catch (err) {
         result.errors.push({
@@ -748,6 +776,7 @@ async function reconcilePromise(opts: { dryRun?: boolean; includePi?: boolean } 
   if (opts.includePi ?? true) {
     const piResult = await reconcilePiTranscripts();
     result.sessionsScanned += piResult.sessionsScanned;
+    result.cacheSkipped += piResult.cacheSkipped;
     result.sessionsWithNewData += piResult.sessionsWithNewData;
     result.eventsImported += piResult.eventsImported;
     result.duplicatesSkipped += piResult.duplicatesSkipped;

--- a/src/lib/costs/skip-cache.ts
+++ b/src/lib/costs/skip-cache.ts
@@ -1,0 +1,41 @@
+import { getOverdeckDatabaseSync } from '../overdeck/infra.js';
+
+export type SkipVerdict = 'imported' | 'no-usage' | 'unknown-model' | 'unpriced-model';
+
+type SkipVerdictRow = {
+  verdict: SkipVerdict;
+};
+
+export function lookupSkipVerdict(
+  path: string,
+  mtimeMs: number,
+  size: number,
+): SkipVerdict | null {
+  const row = getOverdeckDatabaseSync()
+    .prepare(`
+      SELECT verdict
+      FROM cost_reconcile_file_state
+      WHERE path = ? AND mtime_ms = ? AND size = ?
+    `)
+    .get(path, mtimeMs, size) as SkipVerdictRow | undefined;
+
+  return row?.verdict ?? null;
+}
+
+export function recordSkipVerdict(
+  path: string,
+  mtimeMs: number,
+  size: number,
+  verdict: SkipVerdict,
+): void {
+  getOverdeckDatabaseSync()
+    .prepare(`
+      INSERT INTO cost_reconcile_file_state (path, mtime_ms, size, verdict)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(path) DO UPDATE SET
+        mtime_ms = excluded.mtime_ms,
+        size = excluded.size,
+        verdict = excluded.verdict
+    `)
+    .run(path, mtimeMs, size, verdict);
+}

--- a/src/lib/overdeck/__tests__/cost-backfill-roots.test.ts
+++ b/src/lib/overdeck/__tests__/cost-backfill-roots.test.ts
@@ -178,7 +178,8 @@ describe('CostWriter.reconcile — codex extra roots', () => {
         imported: 0,
         sessionsScanned: 1,
         eventsImported: 0,
-        duplicatesSkipped: 1,
+        duplicatesSkipped: 0,
+        cacheSkipped: 1,
       });
       expect(insertedValues).toHaveLength(1);
       expect(insertedValues[0]).toMatchObject({

--- a/src/lib/overdeck/__tests__/cost-codex-reconcile.test.ts
+++ b/src/lib/overdeck/__tests__/cost-codex-reconcile.test.ts
@@ -9,7 +9,7 @@ import {
   type OverdeckTestDb,
 } from '../../../../tests/helpers/overdeck-test-db.js';
 import { CostArchive, EventBus } from '../infra.js';
-import { CostWriter, CostWriterLive } from '../cost.js';
+import { collectCodexCostEvents, CostWriter, CostWriterLive } from '../cost.js';
 
 describe('CostWriter.reconcile — codex per-turn update-on-growth', () => {
   let odb: OverdeckTestDb;
@@ -72,6 +72,38 @@ describe('CostWriter.reconcile — codex per-turn update-on-growth', () => {
       cache_read: 2000,
     });
     expect(rows[1]!.cost).toBeGreaterThan(0);
+  });
+
+  it('does not persist a skip verdict during dry run before a write run', async () => {
+    seedCodexAgent(odb, { input: 12000, cached: 4000, output: 800 });
+    const layer = makeWriterLayer(odb);
+
+    const preview = await Effect.runPromise(
+      CostWriter.use((w) => w.reconcile({ source: 'codex', dryRun: true })).pipe(Effect.provide(layer)),
+    );
+    expect(preview).toMatchObject({ imported: 1, cacheSkipped: 0 });
+    expect(readRows(odb)).toHaveLength(0);
+
+    const write = await Effect.runPromise(
+      CostWriter.use((w) => w.reconcile({ source: 'codex' })).pipe(Effect.provide(layer)),
+    );
+    expect(write).toMatchObject({ imported: 1, cacheSkipped: 0 });
+    expect(readRows(odb)).toHaveLength(1);
+  });
+
+  it('returns cold-sweep events in bounded batches', async () => {
+    const rolloutFile = seedCodexAgent(odb, { input: 12000, cached: 4000, output: 800 });
+    appendTokenCount(rolloutFile, { input: 18000, cached: 6000, output: 1500 });
+
+    const first = await collectCodexCostEvents({ maxEvents: 1 });
+    expect(first.events).toHaveLength(1);
+    expect(first.verdicts).toHaveLength(0);
+    expect(first.done).toBe(false);
+
+    const second = await collectCodexCostEvents({ maxEvents: 1, cursor: first.nextCursor ?? undefined });
+    expect(second.events).toHaveLength(1);
+    expect(second.verdicts).toHaveLength(1);
+    expect(second.done).toBe(true);
   });
 });
 

--- a/src/lib/overdeck/__tests__/cost-codex-reconcile.test.ts
+++ b/src/lib/overdeck/__tests__/cost-codex-reconcile.test.ts
@@ -49,7 +49,13 @@ describe('CostWriter.reconcile — codex per-turn update-on-growth', () => {
     const unchanged = await Effect.runPromise(
       CostWriter.use((w) => w.reconcile({ source: 'codex' })).pipe(Effect.provide(layer)),
     );
-    expect(unchanged).toMatchObject({ imported: 0, eventsImported: 0, duplicatesSkipped: 1, skipped: [] });
+    expect(unchanged).toMatchObject({
+      imported: 0,
+      eventsImported: 0,
+      duplicatesSkipped: 0,
+      cacheSkipped: 1,
+      skipped: [],
+    });
     expect(readRows(odb)).toHaveLength(1);
 
     appendTokenCount(rolloutFile, { input: 18000, cached: 6000, output: 1500 });

--- a/src/lib/overdeck/__tests__/cost-codex-reconcile.test.ts
+++ b/src/lib/overdeck/__tests__/cost-codex-reconcile.test.ts
@@ -94,16 +94,15 @@ describe('CostWriter.reconcile — codex per-turn update-on-growth', () => {
   it('returns cold-sweep events in bounded batches', async () => {
     const rolloutFile = seedCodexAgent(odb, { input: 12000, cached: 4000, output: 800 });
     appendTokenCount(rolloutFile, { input: 18000, cached: 6000, output: 1500 });
+    const batches: Array<{ events: unknown[]; verdicts: unknown[] }> = [];
 
-    const first = await collectCodexCostEvents({ maxEvents: 1 });
-    expect(first.events).toHaveLength(1);
-    expect(first.verdicts).toHaveLength(0);
-    expect(first.done).toBe(false);
-
-    const second = await collectCodexCostEvents({ maxEvents: 1, cursor: first.nextCursor ?? undefined });
-    expect(second.events).toHaveLength(1);
-    expect(second.verdicts).toHaveLength(1);
-    expect(second.done).toBe(true);
+    const result = await collectCodexCostEvents({
+      maxEvents: 1,
+      onBatch: async batch => { batches.push(batch); },
+    });
+    expect(batches.map(batch => batch.events.length)).toEqual([1, 1, 0]);
+    expect(batches.at(-1)?.verdicts).toHaveLength(1);
+    expect(result.events).toHaveLength(0);
   });
 });
 

--- a/src/lib/overdeck/__tests__/schema-audit.test.ts
+++ b/src/lib/overdeck/__tests__/schema-audit.test.ts
@@ -98,6 +98,14 @@ describe('overdeck schema audit', () => {
   it('warns for each missing artifact at startup without repairing the schema', () => {
     const dbPath = makeDbPath();
     const setup = createInitializedDatabase(dbPath);
+    setup.exec(`
+      CREATE TABLE cost_reconcile_file_state (
+        path TEXT PRIMARY KEY NOT NULL,
+        mtime_ms INTEGER NOT NULL,
+        size INTEGER NOT NULL,
+        verdict TEXT NOT NULL
+      )
+    `);
     removeExpectedArtifacts(setup);
     const schemaVersion = setup.pragma('schema_version', { simple: true });
     setup.close();

--- a/src/lib/overdeck/cost.ts
+++ b/src/lib/overdeck/cost.ts
@@ -619,7 +619,6 @@ export const CostWriterLive = Layer.effect(
           warnings: [],
         };
         if (source !== 'ohmypi' && source !== 'codex') return empty;
-
         const agentsDir = join(getOverdeckHome(), 'agents');
         const agentNames = yield* Effect.sync(() => {
           if (!existsSync(agentsDir)) return [] as string[];
@@ -627,7 +626,6 @@ export const CostWriterLive = Layer.effect(
             .filter(e => e.isDirectory())
             .map(e => e.name);
         });
-
         let imported = 0;
         let cacheSkipped = 0;
         const skipped: SkippedCostSession[] = [];
@@ -647,7 +645,6 @@ export const CostWriterLive = Layer.effect(
             `[cost-reconcile] warning ${warning.file}: ${warning.reason} provider=${warning.provider ?? 'unknown'} model=${warning.model}`,
           );
         };
-
         const noteImportedTimestamp = (ts: Date) => {
           const iso = ts.toISOString();
           if (earliestEventTs == null || iso < earliestEventTs) earliestEventTs = iso;
@@ -795,7 +792,6 @@ export const CostWriterLive = Layer.effect(
               cacheSkipped++;
               continue;
             }
-
             const parsed = yield* Effect.sync(() => {
               try {
                 return { ok: true as const, events: parseCodexSessionCostEventsSync(sessionFile) };
@@ -812,9 +808,7 @@ export const CostWriterLive = Layer.effect(
               continue;
             }
             const hasUnknownModel = events.some((event) => event.model === 'unknown');
-            if (hasUnknownModel) {
-              markSkipped(sessionFile, 'unknown-model');
-            }
+            if (hasUnknownModel) markSkipped(sessionFile, 'unknown-model');
             const codexSession = root.inferIssueFromCwd
               ? yield* Effect.sync(() => parseCodexSessionSync(sessionFile))
               : null;
@@ -847,20 +841,12 @@ export const CostWriterLive = Layer.effect(
                 duplicatesSkipped++;
               }
             }
-            recordSkipVerdict(
-              sessionFile,
-              fileStat.mtimeMs,
-              fileStat.size,
-              hasUnknownModel ? 'unknown-model' : 'imported',
-            );
+            recordSkipVerdict(sessionFile, fileStat.mtimeMs, fileStat.size,
+              hasUnknownModel ? 'unknown-model' : 'imported');
           }
         }
-
         return {
-          imported,
-          cacheSkipped,
-          skipped,
-          sessionsScanned,
+          imported, cacheSkipped, skipped, sessionsScanned,
           eventsImported: imported,
           duplicatesSkipped,
           errors,

--- a/src/lib/overdeck/cost.ts
+++ b/src/lib/overdeck/cost.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { Context, Effect, Layer, Schema } from 'effect';
@@ -19,6 +19,7 @@ import { parseOhmypiSessionCostResultSync } from '../cost-parsers/ohmypi-parser.
 import { parseCodexSessionCostEventsSync, parseCodexSessionSync } from '../cost-parsers/codex-parser.js';
 import { getOverdeckHome } from '../paths.js';
 import { deriveTieredAgentCostRole } from '../agents/tier-metrics.js';
+import { lookupSkipVerdict, recordSkipVerdict } from '../costs/skip-cache.js';
 
 // ── Filesystem helpers ────────────────────────────────────────────────────────
 
@@ -168,6 +169,7 @@ export type BudgetStatus = typeof BudgetStatus.Type;
 
 export interface CostReconcileSummary {
   imported: number;
+  cacheSkipped: number;
   skipped: SkippedCostSession[];
   sessionsScanned: number;
   eventsImported: number;
@@ -606,6 +608,7 @@ export const CostWriterLive = Layer.effect(
         const source = opts?.source ?? 'claude';
         const empty: CostReconcileSummary = {
           imported: 0,
+          cacheSkipped: 0,
           skipped: [],
           sessionsScanned: 0,
           eventsImported: 0,
@@ -626,6 +629,7 @@ export const CostWriterLive = Layer.effect(
         });
 
         let imported = 0;
+        let cacheSkipped = 0;
         const skipped: SkippedCostSession[] = [];
         let duplicatesSkipped = 0;
         let sessionsScanned = 0;
@@ -786,19 +790,29 @@ export const CostWriterLive = Layer.effect(
               continue;
             }
 
-            const events = yield* Effect.sync(() => {
-              try {
-                return parseCodexSessionCostEventsSync(sessionFile);
-              } catch (cause) {
-                errors.push(`${sessionFile}: ${cause instanceof Error ? cause.message : String(cause)}`);
-                return [];
-              }
-            });
-            if (events.length === 0) {
-              markSkipped(sessionFile, 'no-usage');
+            const fileStat = yield* Effect.sync(() => statSync(sessionFile));
+            if (lookupSkipVerdict(sessionFile, fileStat.mtimeMs, fileStat.size)) {
+              cacheSkipped++;
               continue;
             }
-            if (events.some((event) => event.model === 'unknown')) {
+
+            const parsed = yield* Effect.sync(() => {
+              try {
+                return { ok: true as const, events: parseCodexSessionCostEventsSync(sessionFile) };
+              } catch (cause) {
+                errors.push(`${sessionFile}: ${cause instanceof Error ? cause.message : String(cause)}`);
+                return { ok: false as const, events: [] };
+              }
+            });
+            if (!parsed.ok) continue;
+            const events = parsed.events;
+            if (events.length === 0) {
+              markSkipped(sessionFile, 'no-usage');
+              recordSkipVerdict(sessionFile, fileStat.mtimeMs, fileStat.size, 'no-usage');
+              continue;
+            }
+            const hasUnknownModel = events.some((event) => event.model === 'unknown');
+            if (hasUnknownModel) {
               markSkipped(sessionFile, 'unknown-model');
             }
             const codexSession = root.inferIssueFromCwd
@@ -833,11 +847,18 @@ export const CostWriterLive = Layer.effect(
                 duplicatesSkipped++;
               }
             }
+            recordSkipVerdict(
+              sessionFile,
+              fileStat.mtimeMs,
+              fileStat.size,
+              hasUnknownModel ? 'unknown-model' : 'imported',
+            );
           }
         }
 
         return {
           imported,
+          cacheSkipped,
           skipped,
           sessionsScanned,
           eventsImported: imported,

--- a/src/lib/overdeck/cost.ts
+++ b/src/lib/overdeck/cost.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { Context, Effect, Layer, Schema } from 'effect';
@@ -16,10 +16,11 @@ import {
 } from '../cost.js';
 import type { CostBudget } from '../cost.js';
 import { parseOhmypiSessionCostResultSync } from '../cost-parsers/ohmypi-parser.js';
-import { parseCodexSessionCostEventsSync, parseCodexSessionSync } from '../cost-parsers/codex-parser.js';
 import { getOverdeckHome } from '../paths.js';
 import { deriveTieredAgentCostRole } from '../agents/tier-metrics.js';
-import { lookupSkipVerdict, recordSkipVerdict } from '../costs/skip-cache.js';
+import { recordSkipVerdict } from '../costs/skip-cache.js';
+import { collectCodexCostEvents } from '../costs/codex-collector.js';
+export { collectCodexCostEvents, type SkipVerdictEntry } from '../costs/codex-collector.js';
 
 // ── Filesystem helpers ────────────────────────────────────────────────────────
 
@@ -619,6 +620,30 @@ export const CostWriterLive = Layer.effect(
           warnings: [],
         };
         if (source !== 'ohmypi' && source !== 'codex') return empty;
+        if (source === 'codex') {
+          const collected = yield* Effect.promise(() => collectCodexCostEvents(opts));
+          let imported = 0;
+          let duplicatesSkipped = 0;
+          let earliestEventTs: string | null = null;
+          let latestEventTs: string | null = null;
+          for (const skipped of collected.skipped) {
+            console.warn(`[cost-reconcile] skipped ${skipped.file}: ${skipped.reason}`);
+          }
+          for (const event of collected.events) {
+            if (yield* record(event, { dryRun: opts?.dryRun })) {
+              imported++;
+              const iso = event.ts.toISOString();
+              if (earliestEventTs == null || iso < earliestEventTs) earliestEventTs = iso;
+              if (latestEventTs == null || iso > latestEventTs) latestEventTs = iso;
+            } else duplicatesSkipped++;
+          }
+          for (const verdict of collected.verdicts) {
+            recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
+          }
+          return { imported, cacheSkipped: collected.stats.cacheSkipped, skipped: collected.skipped,
+            sessionsScanned: collected.stats.scanned, eventsImported: imported, duplicatesSkipped,
+            errors: collected.errors, earliestEventTs, latestEventTs, warnings: [] };
+        }
         const agentsDir = join(getOverdeckHome(), 'agents');
         const agentNames = yield* Effect.sync(() => {
           if (!existsSync(agentsDir)) return [] as string[];
@@ -660,37 +685,13 @@ export const CostWriterLive = Layer.effect(
         };
 
         const roots: ScanRoot[] = agentNames.map((agentName) => ({
-          root: source === 'ohmypi'
-            ? join(agentsDir, agentName, 'sessions')
-            : join(agentsDir, agentName, 'codex-home', 'sessions'),
+          root: join(agentsDir, agentName, 'sessions'),
           agentName,
           issueId: issueIdFromAgentName(agentName),
-          sessionType: source,
+          sessionType: 'ohmypi',
         }));
 
-        if (source === 'codex') {
-          for (const root of opts?.extraRoots ?? []) {
-            roots.push({
-              root,
-              agentName: 'codex-global',
-              issueId: null,
-              sessionType: 'codex',
-              inferIssueFromCwd: true,
-            });
-          }
-        }
-
         for (const extra of opts?.extraRootSpecs ?? []) {
-          if (source === 'codex' && extra.kind === 'codex-global') {
-            roots.push({
-              root: extra.root,
-              agentName: 'codex-global',
-              issueId: null,
-              sessionType: 'codex',
-              inferIssueFromCwd: true,
-            });
-          }
-
           if (source === 'ohmypi' && extra.kind === 'ohmypi-global') {
             const encodedRoots = yield* Effect.sync(() => {
               if (!existsSync(extra.root)) return [] as ScanRoot[];
@@ -787,62 +788,6 @@ export const CostWriterLive = Layer.effect(
               continue;
             }
 
-            const fileStat = yield* Effect.sync(() => statSync(sessionFile));
-            if (lookupSkipVerdict(sessionFile, fileStat.mtimeMs, fileStat.size)) {
-              cacheSkipped++;
-              continue;
-            }
-            const parsed = yield* Effect.sync(() => {
-              try {
-                return { ok: true as const, events: parseCodexSessionCostEventsSync(sessionFile) };
-              } catch (cause) {
-                errors.push(`${sessionFile}: ${cause instanceof Error ? cause.message : String(cause)}`);
-                return { ok: false as const, events: [] };
-              }
-            });
-            if (!parsed.ok) continue;
-            const events = parsed.events;
-            if (events.length === 0) {
-              markSkipped(sessionFile, 'no-usage');
-              recordSkipVerdict(sessionFile, fileStat.mtimeMs, fileStat.size, 'no-usage');
-              continue;
-            }
-            const hasUnknownModel = events.some((event) => event.model === 'unknown');
-            if (hasUnknownModel) markSkipped(sessionFile, 'unknown-model');
-            const codexSession = root.inferIssueFromCwd
-              ? yield* Effect.sync(() => parseCodexSessionSync(sessionFile))
-              : null;
-            const issueId = root.inferIssueFromCwd
-              ? (inferIssueFromPath(codexSession?.cwd) ?? 'UNKNOWN' as IssueIdType)
-              : root.issueId;
-            for (const usage of events) {
-              const ts = new Date(usage.timestamp);
-              const event: CostEvent = {
-                ts,
-                issueId,
-                agentId:     root.agentName,
-                sessionId:   usage.sessionId,
-                sessionType: root.sessionType,
-                provider:    usage.provider,
-                model:       usage.model,
-                input:       usage.input,
-                output:      usage.output,
-                cacheRead:   usage.cacheRead,
-                cacheWrite:  usage.cacheWrite,
-                cost:        usage.cost,
-                requestId:   usage.requestId,
-                sourceFile:  sessionFile,
-              };
-
-              if (yield* record(event, { dryRun: opts?.dryRun })) {
-                imported++;
-                noteImportedTimestamp(ts);
-              } else {
-                duplicatesSkipped++;
-              }
-            }
-            recordSkipVerdict(sessionFile, fileStat.mtimeMs, fileStat.size,
-              hasUnknownModel ? 'unknown-model' : 'imported');
           }
         }
         return {

--- a/src/lib/overdeck/cost.ts
+++ b/src/lib/overdeck/cost.ts
@@ -637,8 +637,10 @@ export const CostWriterLive = Layer.effect(
               if (latestEventTs == null || iso > latestEventTs) latestEventTs = iso;
             } else duplicatesSkipped++;
           }
-          for (const verdict of collected.verdicts) {
-            recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
+          if (!opts?.dryRun) {
+            for (const verdict of collected.verdicts) {
+              recordSkipVerdict(verdict.path, verdict.mtimeMs, verdict.size, verdict.verdict);
+            }
           }
           return { imported, cacheSkipped: collected.stats.cacheSkipped, skipped: collected.skipped,
             sessionsScanned: collected.stats.scanned, eventsImported: imported, duplicatesSkipped,

--- a/src/lib/overdeck/infra.ts
+++ b/src/lib/overdeck/infra.ts
@@ -185,6 +185,7 @@ function ensureRuntimeIndexesSync(db: SqliteDatabase): void {
   runSchemaTopUp(db, 'CREATE INDEX IF NOT EXISTS `cost_session_id_idx` ON `cost_events` (`session_id`)');
   runSchemaTopUp(db, 'CREATE INDEX IF NOT EXISTS `idx_cost_agent_id` ON `cost_events` (`agent_id`, `ts`)');
   runSchemaTopUp(db, 'CREATE INDEX IF NOT EXISTS `idx_cost_issue_upper` ON `cost_events` (UPPER(`issue_id`))');
+  runSchemaTopUp(db, 'CREATE TABLE IF NOT EXISTS `cost_reconcile_file_state` (`path` text PRIMARY KEY NOT NULL, `mtime_ms` integer NOT NULL, `size` integer NOT NULL, `verdict` text NOT NULL)');
   // PAN-2507: preemptive-scheduler yield attribution on agents. The init
   // migration only runs on a fresh DB, so existing overdeck.db files need these
   // columns added idempotently here.

--- a/tests/unit/dashboard/cost-reconcile-sweep-job.test.ts
+++ b/tests/unit/dashboard/cost-reconcile-sweep-job.test.ts
@@ -3,14 +3,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../../../src/lib/overdeck/cost.js', () => ({
   collectCodexCostEvents: vi.fn(),
 }));
+vi.mock('../../../src/lib/costs/reconciler.js', () => ({
+  collectPiCostEvents: vi.fn(),
+}));
 
 import { collectCodexCostEvents } from '../../../src/lib/overdeck/cost.js';
+import { collectPiCostEvents } from '../../../src/lib/costs/reconciler.js';
 import { runDashboardDbJob, workerLane } from '../../../src/dashboard/server/services/dashboard-db-task.js';
 
 describe('cost reconcile worker job', () => {
   beforeEach(() => {
     vi.mocked(collectCodexCostEvents).mockReset().mockResolvedValue({
       events: [], verdicts: [], stats: { scanned: 3, cacheSkipped: 2 }, skipped: [], errors: [],
+    });
+    vi.mocked(collectPiCostEvents).mockReset().mockResolvedValue({
+      events: [], verdicts: [], stats: { scanned: 2, cacheSkipped: 1, sessionsWithData: 0 }, errors: [],
     });
   });
 
@@ -23,5 +30,12 @@ describe('cost reconcile worker job', () => {
 
     expect(collectCodexCostEvents).toHaveBeenCalledOnce();
     expect(result).toMatchObject({ stats: { scanned: 3, cacheSkipped: 2 } });
+  });
+
+  it('dispatches the pi collector for a pi sweep payload', async () => {
+    const result = await runDashboardDbJob('costReconcileSweep', { source: 'pi' });
+
+    expect(collectPiCostEvents).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ stats: { scanned: 2, cacheSkipped: 1 } });
   });
 });

--- a/tests/unit/dashboard/cost-reconcile-sweep-job.test.ts
+++ b/tests/unit/dashboard/cost-reconcile-sweep-job.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/lib/overdeck/cost.js', () => ({
+  collectCodexCostEvents: vi.fn(),
+}));
+
+import { collectCodexCostEvents } from '../../../src/lib/overdeck/cost.js';
+import { runDashboardDbJob, workerLane } from '../../../src/dashboard/server/services/dashboard-db-task.js';
+
+describe('cost reconcile worker job', () => {
+  beforeEach(() => {
+    vi.mocked(collectCodexCostEvents).mockReset().mockResolvedValue({
+      events: [], verdicts: [], stats: { scanned: 3, cacheSkipped: 2 }, skipped: [], errors: [],
+    });
+  });
+
+  it('routes costReconcileSweep to the long worker lane', () => {
+    expect(workerLane('costReconcileSweep')).toBe('long');
+  });
+
+  it('dispatches the codex collector through the database job surface', async () => {
+    const result = await runDashboardDbJob('costReconcileSweep', { source: 'codex' });
+
+    expect(collectCodexCostEvents).toHaveBeenCalledOnce();
+    expect(result).toMatchObject({ stats: { scanned: 3, cacheSkipped: 2 } });
+  });
+});

--- a/tests/unit/dashboard/db-task-instrumentation.test.ts
+++ b/tests/unit/dashboard/db-task-instrumentation.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/lib/overdeck/cost.js', () => ({
+  collectCodexCostEvents: vi.fn(async () => ({ events: [], verdicts: [], stats: { scanned: 0, cacheSkipped: 0 } })),
+}));
+vi.mock('../../../src/lib/costs/reconciler.js', () => ({ collectPiCostEvents: vi.fn() }));
+
+import {
+  formatSlowJobLine,
+  runDashboardDbJob,
+} from '../../../src/dashboard/server/services/dashboard-db-task.js';
+
+describe('dashboard database job instrumentation', () => {
+  it('formats queue wait from enqueue and start stamps', () => {
+    const enqueuedAt = 1_000;
+    const startedAt = 2_250;
+    const finishedAt = 2_500;
+
+    expect(formatSlowJobLine({
+      op: 'listSessionsFeed', lane: 'read',
+      waitMs: startedAt - enqueuedAt, runMs: finishedAt - startedAt, depth: 3,
+    })).toBe('[db-jobs] slow: op=listSessionsFeed lane=read waitMs=1250 runMs=250 depth=3');
+  });
+
+  it('formats worker run time above one second', () => {
+    expect(formatSlowJobLine({
+      op: 'costReconcileSweep', lane: 'long', waitMs: 20, runMs: 1_001, depth: 0,
+    })).toBe('[db-jobs] slow: op=costReconcileSweep lane=long waitMs=20 runMs=1001 depth=0');
+  });
+
+  it('returns null when wait and run time are at the threshold', () => {
+    expect(formatSlowJobLine({
+      op: 'getDiscoveredStats', lane: 'read', waitMs: 1_000, runMs: 1_000, depth: 0,
+    })).toBeNull();
+  });
+
+  it('logs the same line shape for a slow inline job with zero wait', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.spyOn(Date, 'now').mockReturnValueOnce(1_000).mockReturnValueOnce(2_001);
+
+    await runDashboardDbJob('costReconcileSweep', { source: 'codex' });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[db-jobs] slow: op=costReconcileSweep lane=long waitMs=0 runMs=1001 depth=0',
+    );
+  });
+});

--- a/tests/unit/dashboard/db-task-lanes.test.ts
+++ b/tests/unit/dashboard/db-task-lanes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type DashboardDbOperation,
+  workerLane,
+} from '../../../src/dashboard/server/services/dashboard-db-task.js';
+
+describe('dashboard database worker lanes', () => {
+  it.each([
+    'listSessionsFeed',
+    'getSessionsFeedFacets',
+    'getConversationByName',
+    'getDiscoveredSessionById',
+  ] satisfies DashboardDbOperation[])('routes interactive operation %s to read', operation => {
+    expect(workerLane(operation)).toBe('read');
+  });
+
+  it.each([
+    'scanConversations',
+    'enrichSessions',
+    'embedSessions',
+    'listSubstrateBugWeights',
+    'costReconcileSweep',
+  ] satisfies DashboardDbOperation[])('routes bulk operation %s to long', operation => {
+    expect(workerLane(operation)).toBe('long');
+  });
+
+  it('routes semantic search to its dedicated lane', () => {
+    expect(workerLane('searchSessionsSemantic')).toBe('semantic');
+  });
+});

--- a/tests/unit/lib/costs/codex-skip-cache.test.ts
+++ b/tests/unit/lib/costs/codex-skip-cache.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, mkdirSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Effect, Layer } from 'effect';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../../src/lib/cost-parsers/codex-parser.js', () => ({
+  parseCodexSessionCostEventsSync: vi.fn(),
+  parseCodexSessionSync: vi.fn(() => null),
+}));
+
+import { parseCodexSessionCostEventsSync } from '../../../../src/lib/cost-parsers/codex-parser.js';
+import { CostWriter, CostWriterLive } from '../../../../src/lib/overdeck/cost.js';
+import {
+  closeOverdeckDatabaseSync,
+  CostArchiveLive,
+  EventBusLive,
+  getOverdeckDatabaseSync,
+  makeDbLive,
+} from '../../../../src/lib/overdeck/infra.js';
+
+let testHome: string;
+let sessionFile: string;
+
+function makeLayer() {
+  const dbLayer = makeDbLive(join(testHome, 'overdeck.db'));
+  return CostWriterLive.pipe(Layer.provide(Layer.mergeAll(
+    dbLayer,
+    EventBusLive.pipe(Layer.provide(dbLayer)),
+    CostArchiveLive,
+  )));
+}
+
+function usageEvent() {
+  return {
+    requestId: 'codex:sess-1:0',
+    timestamp: '2026-08-16T10:00:00Z',
+    sessionId: 'sess-1',
+    provider: 'openai',
+    model: 'gpt-5.5',
+    input: 10,
+    output: 2,
+    cacheRead: 0,
+    cacheWrite: 0,
+    cost: 0.001,
+  };
+}
+
+async function reconcile() {
+  return Effect.runPromise(
+    CostWriter.use((writer) => writer.reconcile({ source: 'codex' })).pipe(
+      Effect.provide(makeLayer()),
+    ),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  testHome = mkdtempSync(join(tmpdir(), 'pan-3743-codex-cache-'));
+  process.env.OVERDECK_HOME = testHome;
+  const sessionDir = join(testHome, 'agents', 'agent-pan-3743', 'codex-home', 'sessions');
+  mkdirSync(sessionDir, { recursive: true });
+  sessionFile = join(sessionDir, 'rollout.jsonl');
+  writeFileSync(sessionFile, '{}\n');
+  getOverdeckDatabaseSync();
+  closeOverdeckDatabaseSync();
+  vi.mocked(parseCodexSessionCostEventsSync).mockReturnValue([usageEvent()]);
+});
+
+afterEach(() => {
+  closeOverdeckDatabaseSync();
+  delete process.env.OVERDECK_HOME;
+  rmSync(testHome, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('codex reconcile skip cache', () => {
+  it('does not parse or emit per-file skip logs for an unchanged cached file', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    const first = await reconcile();
+    const second = await reconcile();
+
+    expect(first).toMatchObject({ sessionsScanned: 1, cacheSkipped: 0 });
+    expect(second).toMatchObject({ sessionsScanned: 1, cacheSkipped: 1 });
+    expect(parseCodexSessionCostEventsSync).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('[cost-reconcile] skipped'));
+  });
+
+  it('re-parses a cached file after its mtime changes', async () => {
+    await reconcile();
+    const changed = new Date(Date.now() + 10_000);
+    utimesSync(sessionFile, changed, changed);
+
+    const result = await reconcile();
+
+    expect(result.cacheSkipped).toBe(0);
+    expect(parseCodexSessionCostEventsSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache parse failures', async () => {
+    vi.mocked(parseCodexSessionCostEventsSync).mockImplementation(() => {
+      throw new Error('broken transcript');
+    });
+
+    await reconcile();
+    await reconcile();
+
+    expect(parseCodexSessionCostEventsSync).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/unit/lib/costs/reconciler-collect.test.ts
+++ b/tests/unit/lib/costs/reconciler-collect.test.ts
@@ -47,4 +47,28 @@ describe('collectPiCostEvents', () => {
     expect(result.verdicts).toHaveLength(1);
     expect(result.verdicts[0]?.verdict).toBe('imported');
   });
+
+  it('returns large transcripts in bounded event batches', async () => {
+    const agentDir = join(root, '.overdeck', 'agents', 'agent-pan-3743');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'state.json'), JSON.stringify({ issueId: 'PAN-3743', role: 'work' }));
+    writeFileSync(join(agentDir, 'session.jsonl'), [
+      '{"type":"session","version":3}',
+      ...['m1', 'm2'].map((id, index) => JSON.stringify({
+        type: 'message', id, timestamp: `2026-08-16T10:00:0${index}Z`,
+        message: { role: 'assistant', provider: 'zai', model: 'glm-5.2', responseId: `r${index}`,
+          usage: { input: 10, output: 2, cacheRead: 0, cacheWrite: 0 } },
+      })),
+    ].join('\n'));
+
+    const first = await collectPiCostEvents({ maxEvents: 1 });
+    expect(first.events).toHaveLength(1);
+    expect(first.verdicts).toHaveLength(0);
+    expect(first.done).toBe(false);
+
+    const second = await collectPiCostEvents({ maxEvents: 1, cursor: first.nextCursor ?? undefined });
+    expect(second.events).toHaveLength(1);
+    expect(second.verdicts).toHaveLength(1);
+    expect(second.done).toBe(true);
+  });
 });

--- a/tests/unit/lib/costs/reconciler-collect.test.ts
+++ b/tests/unit/lib/costs/reconciler-collect.test.ts
@@ -61,14 +61,14 @@ describe('collectPiCostEvents', () => {
       })),
     ].join('\n'));
 
-    const first = await collectPiCostEvents({ maxEvents: 1 });
-    expect(first.events).toHaveLength(1);
-    expect(first.verdicts).toHaveLength(0);
-    expect(first.done).toBe(false);
+    const batches: Array<{ events: unknown[]; verdicts: unknown[] }> = [];
+    const result = await collectPiCostEvents({
+      maxEvents: 1,
+      onBatch: async batch => { batches.push(batch); },
+    });
 
-    const second = await collectPiCostEvents({ maxEvents: 1, cursor: first.nextCursor ?? undefined });
-    expect(second.events).toHaveLength(1);
-    expect(second.verdicts).toHaveLength(1);
-    expect(second.done).toBe(true);
+    expect(batches.map(batch => batch.events.length)).toEqual([1, 1, 0]);
+    expect(batches.at(-1)?.verdicts).toHaveLength(1);
+    expect(result.events).toHaveLength(0);
   });
 });

--- a/tests/unit/lib/costs/reconciler-collect.test.ts
+++ b/tests/unit/lib/costs/reconciler-collect.test.ts
@@ -1,0 +1,50 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { collectPiCostEvents } from '../../../../src/lib/costs/reconciler.js';
+import { closeOverdeckDatabaseSync, getOverdeckDatabaseSync } from '../../../../src/lib/overdeck/infra.js';
+
+let root: string;
+let previousHome: string | undefined;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'pan-3743-pi-collect-'));
+  previousHome = process.env.HOME;
+  process.env.HOME = root;
+  process.env.OVERDECK_HOME = join(root, '.overdeck');
+  getOverdeckDatabaseSync();
+  closeOverdeckDatabaseSync();
+});
+
+afterEach(() => {
+  closeOverdeckDatabaseSync();
+  if (previousHome === undefined) delete process.env.HOME;
+  else process.env.HOME = previousHome;
+  delete process.env.OVERDECK_HOME;
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe('collectPiCostEvents', () => {
+  it('returns parsed events and verdicts without recording them', async () => {
+    const agentDir = join(root, '.overdeck', 'agents', 'agent-pan-3743');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'state.json'), JSON.stringify({ issueId: 'PAN-3743', role: 'work' }));
+    writeFileSync(join(agentDir, 'session.jsonl'), [
+      '{"type":"session","version":3}',
+      JSON.stringify({ type: 'message', id: 'm1', timestamp: '2026-08-16T10:00:00Z',
+        message: { role: 'assistant', provider: 'zai', model: 'glm-5.2', responseId: 'r1',
+          usage: { input: 10, output: 2, cacheRead: 0, cacheWrite: 0 } } }),
+    ].join('\n'));
+
+    const result = await collectPiCostEvents();
+
+    expect(result.stats).toEqual({ scanned: 1, cacheSkipped: 0, sessionsWithData: 1 });
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]?.event).toMatchObject({ issueId: 'PAN-3743', agentId: 'agent-pan-3743' });
+    expect(result.verdicts).toHaveLength(1);
+    expect(result.verdicts[0]?.verdict).toBe('imported');
+  });
+});

--- a/tests/unit/lib/costs/reconciler-skip-cache.test.ts
+++ b/tests/unit/lib/costs/reconciler-skip-cache.test.ts
@@ -1,0 +1,61 @@
+import { closeSync, mkdtempSync, mkdirSync, openSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { reconcilePiTranscripts } from '../../../../src/lib/costs/reconciler.js';
+import { closeOverdeckDatabaseSync, getOverdeckDatabaseSync } from '../../../../src/lib/overdeck/infra.js';
+
+let testHome: string;
+let agentDir: string;
+let previousHome: string | undefined;
+
+beforeEach(() => {
+  testHome = mkdtempSync(join(tmpdir(), 'pan-3743-pi-cache-'));
+  previousHome = process.env.HOME;
+  process.env.HOME = testHome;
+  process.env.OVERDECK_HOME = join(testHome, '.overdeck');
+  agentDir = join(testHome, '.overdeck', 'agents', 'agent-pan-3743');
+  mkdirSync(agentDir, { recursive: true });
+  getOverdeckDatabaseSync();
+  closeOverdeckDatabaseSync();
+});
+
+afterEach(() => {
+  closeOverdeckDatabaseSync();
+  if (previousHome === undefined) delete process.env.HOME;
+  else process.env.HOME = previousHome;
+  delete process.env.OVERDECK_HOME;
+  rmSync(testHome, { recursive: true, force: true });
+});
+
+describe('pi reconcile skip cache', () => {
+  it('skips opening an unchanged transcript after caching its terminal verdict', async () => {
+    const transcript = join(agentDir, 'session.jsonl');
+    writeFileSync(transcript, '{"type":"session","version":3}\n');
+
+    const first = await reconcilePiTranscripts();
+    const second = await reconcilePiTranscripts();
+
+    expect(first).toMatchObject({ sessionsScanned: 1, cacheSkipped: 0 });
+    expect(second).toMatchObject({ sessionsScanned: 1, cacheSkipped: 1 });
+    expect(() => {
+      const fd = openSync(transcript, 'r');
+      closeSync(fd);
+    }).not.toThrow();
+  });
+
+  it('retries a file that was unreadable during the previous sweep', async () => {
+    const transcript = join(agentDir, 'session.jsonl');
+    const missingTarget = join(testHome, 'missing.jsonl');
+    symlinkSync(missingTarget, transcript);
+
+    const first = await reconcilePiTranscripts();
+    writeFileSync(missingTarget, '{"type":"session","version":3}\n');
+    const second = await reconcilePiTranscripts();
+
+    expect(first).toMatchObject({ sessionsScanned: 0, cacheSkipped: 0 });
+    expect(second).toMatchObject({ sessionsScanned: 1, cacheSkipped: 0 });
+  });
+});

--- a/tests/unit/lib/costs/skip-cache.test.ts
+++ b/tests/unit/lib/costs/skip-cache.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  lookupSkipVerdict,
+  recordSkipVerdict,
+  type SkipVerdict,
+} from '../../../../src/lib/costs/skip-cache.js';
+import {
+  closeOverdeckDatabaseSync,
+  getOverdeckDatabaseSync,
+} from '../../../../src/lib/overdeck/infra.js';
+
+let testHome: string;
+
+beforeEach(() => {
+  testHome = mkdtempSync(join(tmpdir(), 'pan-3743-skip-cache-'));
+  process.env.OVERDECK_HOME = testHome;
+});
+
+afterEach(() => {
+  closeOverdeckDatabaseSync();
+  delete process.env.OVERDECK_HOME;
+  rmSync(testHome, { recursive: true, force: true });
+});
+
+describe('cost reconcile skip cache', () => {
+  it('creates the file-state table with the expected columns', () => {
+    const columns = getOverdeckDatabaseSync()
+      .prepare('PRAGMA table_info(cost_reconcile_file_state)')
+      .all() as Array<{ name: string }>;
+
+    expect(columns.map(({ name }) => name)).toEqual(['path', 'mtime_ms', 'size', 'verdict']);
+  });
+
+  it('returns a recorded verdict for an exact file stat match', () => {
+    recordSkipVerdict('/sessions/a.jsonl', 1_000, 200, 'no-usage');
+
+    expect(lookupSkipVerdict('/sessions/a.jsonl', 1_000, 200)).toBe('no-usage');
+  });
+
+  it('returns null when the file mtime changes', () => {
+    recordSkipVerdict('/sessions/a.jsonl', 1_000, 200, 'imported');
+
+    expect(lookupSkipVerdict('/sessions/a.jsonl', 1_001, 200)).toBeNull();
+  });
+
+  it('returns null when the file size changes', () => {
+    recordSkipVerdict('/sessions/a.jsonl', 1_000, 200, 'unknown-model');
+
+    expect(lookupSkipVerdict('/sessions/a.jsonl', 1_000, 201)).toBeNull();
+  });
+
+  it('returns null for an unknown path', () => {
+    expect(lookupSkipVerdict('/sessions/missing.jsonl', 1_000, 200)).toBeNull();
+  });
+
+  it('only admits terminal verdicts at the type boundary', () => {
+    const verdicts = [
+      'imported',
+      'no-usage',
+      'unknown-model',
+      'unpriced-model',
+    ] satisfies SkipVerdict[];
+
+    expect(verdicts).toHaveLength(4);
+    // @ts-expect-error Error outcomes must be retried and cannot be cached.
+    const errorVerdict: SkipVerdict = 'error';
+    // @ts-expect-error Unreadable files must be retried and cannot be cached.
+    const unreadableVerdict: SkipVerdict = 'unreadable';
+    expect([errorVerdict, unreadableVerdict]).toEqual(['error', 'unreadable']);
+  });
+});

--- a/tests/unit/lib/overdeck/cost-reconcile.test.ts
+++ b/tests/unit/lib/overdeck/cost-reconcile.test.ts
@@ -12,6 +12,7 @@ vi.mock('node:fs', async (importOriginal) => {
     ...actual,
     existsSync: vi.fn(),
     readdirSync: vi.fn(),
+    statSync: vi.fn(() => ({ mtimeMs: 1, size: 1 })),
   };
 });
 
@@ -23,6 +24,11 @@ vi.mock('../../../../src/lib/cost-parsers/ohmypi-parser.js', () => ({
 
 vi.mock('../../../../src/lib/cost-parsers/codex-parser.js', () => ({
   parseCodexSessionCostEventsSync: vi.fn(),
+}));
+
+vi.mock('../../../../src/lib/costs/skip-cache.js', () => ({
+  lookupSkipVerdict: vi.fn(() => null),
+  recordSkipVerdict: vi.fn(),
 }));
 
 vi.mock('../../../../src/lib/paths.js', async (importOriginal) => {


### PR DESCRIPTION
**Issue:** #3743

## Acceptance Criteria

- [ ] Add cost_reconcile_file_state table and skip-cache module
- [ ] Wire skip-verdict cache into the codex sweep in cost.ts
- [ ] Wire skip-verdict cache into reconcilePiTranscripts
- [ ] Worker-ize the codex sweep walk+parse behind costReconcileSweep
- [ ] Worker-ize the pi reconciler walk+parse behind costReconcileSweep
- [ ] Instrument runDashboardDbJob queue wait and run time
- [ ] Pin the workerLane mapping with a unit test
- [ ] Document worker lanes, slow-job log line, and sweep delegation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cost reconciliation for Codex and Pi sessions with scan, import, and skipped-item summaries.
  * Added caching to skip unchanged files during subsequent reconciliations.
  * Added bounded processing for large reconciliation jobs.
* **Bug Fixes**
  * Prevented duplicate processing during repeated cost backfills.
  * Changed or previously unreadable files are retried appropriately.
* **Documentation**
  * Documented dashboard worker lanes and local database job diagnostics.
* **Monitoring**
  * Added slow-job warnings showing queue wait, runtime, and queue depth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->