### PR TITLE
PAN-3754

### DIFF
--- a/docs/RESOURCE-GOVERNOR.md
+++ b/docs/RESOURCE-GOVERNOR.md
@@ -74,10 +74,13 @@ governor mode:
 | `soft` | `holding` | Stop admitting new resumes and new advancing dispatches. Nothing is killed. |
 | `hard` | `shedding` | Admission is blocked. Automatic eviction is not wired; the kernel may start killing processes if memory stays exhausted. |
 
-The governor never re-admits the moment it clears SOFT. It holds until `MemAvailable` exceeds
-RECOVERY — a threshold strictly above SOFT. Without that gap, a system oscillating around SOFT would
-flip between admitting and holding on every patrol, resuming and re-stopping agents in a loop. The
-transition rule (`nextGovernorMode` in `memory-governor.ts`) is:
+The normal recovery path holds until `MemAvailable` exceeds RECOVERY — a threshold strictly above
+SOFT. A second path prevents a transient dip from holding a healthy host indefinitely: when PSI
+`full avg10` stays below `governor_psi_calm_readmit_avg10` continuously for
+`governor_psi_calm_window_ms`, the governor can re-admit at SOFT. The calm window re-arms after every
+early re-admission, so another dip must earn a fresh full window before it can re-admit again.
+Without these conditions, a system oscillating around SOFT could resume and re-stop agents on every
+patrol. The base transition rule (`nextGovernorMode` in `memory-governor.ts`) is:
 
 ```
 available >= RECOVERY  -> admitting
@@ -89,7 +92,7 @@ otherwise                                                -> hold the current mod
 ```
  available RAM
       ^
- RECOVERY ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─  <- only line that re-admits
+ RECOVERY ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─  <- normal re-admission
       │            ┌─────────────┐
    SOFT ─ ─ ─ ─ ─ ─ │   holding   │ ─ ─ ─ ─ ─ ─ ─
       │  admitting  │  (no admit) │
@@ -98,8 +101,8 @@ otherwise                                                -> hold the current mod
       └──────────────────────────────────────> time
 ```
 
-The governor's mode is module-level state, persisted across calls within the process — it is not
-recomputed from scratch each time, which is what makes the hold behavior possible.
+The governor's mode, trigger, and calm-window start are module-level state persisted across calls
+within the process. The verdict carries the trigger kind, trigger-time reading, threshold, and time.
 
 ## Activity-Feed Signals (PAN-3550)
 
@@ -108,10 +111,14 @@ The memory governor's level transitions and kernel OOM kills appear in the dashb
 Four feed levels:
 - **`ok`** — MemAvailable above the watch reserve; Overdeck is admitting work normally.
 - **`watch`** — MemAvailable below the watch reserve but still admitting (band is `ok`). Warning that the soft reserve may soon be crossed.
-- **`holding`** (band `soft`) — Overdeck has stopped admitting new agents and dispatches. Work queues until memory recovers above the recovery reserve.
+- **`holding`** (band `soft`) — Overdeck has stopped admitting new agents and dispatches. Work queues until normal recovery or PSI-calm early re-admission.
 - **`shedding`** (band `hard`) — MemAvailable is below the hard reserve. Overdeck admits nothing; the kernel may OOM-kill. Automatic eviction is not wired.
 
 Top RSS consumers are attributed to Overdeck tmux sessions via `getRuntimeCensus()` (the in-repo runtime census, not the machine-local `.overdeck/logs/memory-census.log`).
+
+Each non-admitting message separates the stored cause from the current reading. For example:
+
+> Overdeck stopped admitting work at 14:22 UTC when available memory dipped to 8.9 GiB, under the 9.4 GiB soft reserve. 12.5 GiB is available now. Admissions resume at the 15.7 GiB recovery reserve, or at the 9.4 GiB soft reserve once memory pressure stalls (PSI full avg10) stay below 0.05 for 10 minutes. Nothing has been stopped or killed.
 
 **OOM Canary** watches the kernel journal for `oom-kill:` lines, parses the victim's pid, command, RSS, and cgroup, and emits one activity entry per kill. The cursor-file pattern ensures no duplicate reporting across patrol ticks or dashboard restarts. On permission error (user not in `adm` group), the canary disables itself gracefully and logs once, never blocking the rest of the patrol.
 
@@ -374,6 +381,8 @@ the normalized in-process config uses the camelCase names shown in parentheses.
 | `governor_swap_soft_free_percent` | `governorSwapSoftFreePercent` | `25` | Below this percentage of free swap, stop admitting. |
 | `governor_swap_recovery_free_percent` | `governorSwapRecoveryFreePercent` | `50` | Free-swap percentage required before re-admission. Always normalized above the swap SOFT percentage, up to 100. |
 | `governor_psi_full_shed_avg10` | `governorPsiFullShedAvg10` | `1` | With low swap, PSI `full avg10` at or above this value upgrades the mode to shedding. |
+| `governor_psi_calm_readmit_avg10` | `governorPsiCalmReadmitAvg10` | `0.05` | PSI `full avg10` must stay below this value for early re-admission at SOFT. |
+| `governor_psi_calm_window_ms` | `governorPsiCalmWindowMs` | `600000` | Continuous calm-PSI time required for early re-admission. The window re-arms after each early re-admission. |
 | `governor_footprint_default_work_gb` | `governorFootprintDefaultWorkGb` | `2` | Cold-start footprint estimate for a work agent. |
 | `governor_footprint_default_review_gb` | `governorFootprintDefaultReviewGb` | `1` | Cold-start footprint estimate for a review agent. |
 | `governor_footprint_default_test_gb` | `governorFootprintDefaultTestGb` | `1` | Cold-start footprint estimate for a test agent. |

--- a/docs/RESOURCE-GOVERNOR.md
+++ b/docs/RESOURCE-GOVERNOR.md
@@ -134,9 +134,11 @@ The governor composes three host signals into that single mode:
   when `full avg10` reaches `governor_psi_full_shed_avg10`.
 
 Swap uses the same hysteresis latch as RAM. After the governor stops admitting, free swap must reach
-`governor_swap_recovery_free_percent` before the swap signal clears. Re-admission requires both
-`MemAvailable >= RECOVERY` and `SwapFree` at or above that recovery percentage, so a machine with
-healthy RAM but exhausted swap does not admit another workspace stack.
+`governor_swap_recovery_free_percent` before the swap signal clears on the normal recovery path.
+That path requires both `MemAvailable >= RECOVERY` and `SwapFree` at or above the recovery
+percentage. PSI-calm early re-admission is the exception: after a fresh full calm window begins in
+the non-admitting state, the governor can re-admit at SOFT even while swap remains below its recovery
+percentage, because idle swap residency without live stalls is not current pressure.
 
 A machine with `SwapTotal = 0` keeps the RAM-only behavior. If PSI is unavailable, low swap still
 holds admissions, but it cannot trigger shedding by itself; only the RAM HARD threshold can do that.

--- a/scripts/file-size-allowlist.txt
+++ b/scripts/file-size-allowlist.txt
@@ -14,6 +14,7 @@
 1259 src/lib/lifecycle/workflows.ts # PAN-3727
 1049 src/lib/config-yaml/schema.ts # PAN-3410
 1068 src/lib/config-yaml/schema.ts # PAN-3658
+1074 src/lib/config-yaml/schema.ts # PAN-3754
 900 src/lib/launcher-generator.ts # PAN-1837
 1186 src/lib/sync.ts # PAN-3450
 1060 src/lib/agents/spawn.ts # PAN-1837

--- a/src/lib/cloister/memory-governor.ts
+++ b/src/lib/cloister/memory-governor.ts
@@ -77,8 +77,14 @@ export interface GovernorRunwayThresholds {
   psiFullShedAvg10: number;
 }
 
+export interface GovernorPsiCalmConfig {
+  readmitAvg10: number;
+  windowMs: number;
+}
+
 let governorMode: GovernorMode = 'admitting';
 let governorTrigger: GovernorTrigger | null = null;
+let psiCalmSinceMs: number | null = null;
 
 export interface GovernorTriggerSeed {
   kind: GovernorTriggerKind;
@@ -95,6 +101,7 @@ export interface GovernorTransition {
 export function resetGovernorModeForTests(): void {
   governorMode = 'admitting';
   governorTrigger = null;
+  psiCalmSinceMs = null;
   setCachedMemoryVerdict(null);
 }
 
@@ -118,6 +125,14 @@ export function readGovernorRunwayThresholds(): GovernorRunwayThresholds {
     swapSoftFreePercent: resources.governorSwapSoftFreePercent,
     swapRecoveryFreePercent: resources.governorSwapRecoveryFreePercent,
     psiFullShedAvg10: resources.governorPsiFullShedAvg10,
+  };
+}
+
+export function readGovernorPsiCalmConfig(): GovernorPsiCalmConfig {
+  const resources = loadConfigSync().config.resources;
+  return {
+    readmitAvg10: resources.governorPsiCalmReadmitAvg10,
+    windowMs: resources.governorPsiCalmWindowMs,
   };
 }
 
@@ -205,7 +220,14 @@ function bandForGovernorMode(mode: GovernorMode): MemoryPressureBand {
 export async function assessMemoryPressure(): Promise<MemoryVerdict> {
   const reserves = readGovernorReserves();
   const runwayThresholds = readGovernorRunwayThresholds();
+  const psiCalmConfig = readGovernorPsiCalmConfig();
   const snapshot = await readProcMemory();
+  const now = Date.now();
+  if (snapshot.psiFullAvg10 != null && snapshot.psiFullAvg10 < psiCalmConfig.readmitAvg10) {
+    psiCalmSinceMs ??= now;
+  } else {
+    psiCalmSinceMs = null;
+  }
   const previousMode = governorMode;
   const transition = nextGovernorModeWithRunway(
     snapshot.memAvailable,
@@ -225,7 +247,17 @@ export async function assessMemoryPressure(): Promise<MemoryVerdict> {
     transition.trigger
     && (previousMode === 'admitting' || transition.trigger.kind !== governorTrigger?.kind)
   ) {
-    governorTrigger = { ...transition.trigger, at: Date.now() };
+    governorTrigger = { ...transition.trigger, at: now };
+  }
+  if (
+    governorMode === 'holding'
+    && psiCalmSinceMs != null
+    && now - psiCalmSinceMs >= psiCalmConfig.windowMs
+    && snapshot.memAvailable >= reserves.softBytes
+  ) {
+    governorMode = 'admitting';
+    governorTrigger = null;
+    psiCalmSinceMs = now;
   }
   const verdict: MemoryVerdict = {
     band: bandForGovernorMode(governorMode),

--- a/src/lib/cloister/memory-governor.ts
+++ b/src/lib/cloister/memory-governor.ts
@@ -173,9 +173,8 @@ export function nextGovernorModeWithRunway(
 
   const swapSoftBytes = runway.swapTotalBytes * runwayThresholds.swapSoftFreePercent / 100;
   const swapRecoveryBytes = runway.swapTotalBytes * runwayThresholds.swapRecoveryFreePercent / 100;
-  const swapLow = previousMode === 'admitting'
-    ? runway.swapFreeBytes < swapSoftBytes
-    : runway.swapFreeBytes < swapRecoveryBytes;
+  const activeSwapThresholdBytes = previousMode === 'admitting' ? swapSoftBytes : swapRecoveryBytes;
+  const swapLow = runway.swapFreeBytes < activeSwapThresholdBytes;
   const psiShed = swapLow
     && runway.psiFullAvg10 != null
     && runway.psiFullAvg10 >= runwayThresholds.psiFullShedAvg10;
@@ -184,7 +183,7 @@ export function nextGovernorModeWithRunway(
   if (psiShed) {
     return {
       mode: 'shedding',
-      trigger: { kind: 'swap-psi', readingBytes: runway.swapFreeBytes, thresholdBytes: swapSoftBytes },
+      trigger: { kind: 'swap-psi', readingBytes: runway.swapFreeBytes, thresholdBytes: activeSwapThresholdBytes },
     };
   }
   // Operator-approved correction (PAN-3485 follow-up, 2026-08-02): swap
@@ -198,7 +197,7 @@ export function nextGovernorModeWithRunway(
   if (swapLow && runway.psiFullAvg10 == null) {
     return {
       mode: 'holding',
-      trigger: { kind: 'psi-unavailable', readingBytes: runway.swapFreeBytes, thresholdBytes: swapSoftBytes },
+      trigger: { kind: 'psi-unavailable', readingBytes: runway.swapFreeBytes, thresholdBytes: activeSwapThresholdBytes },
     };
   }
   return { mode: memoryMode, trigger: memoryTrigger };
@@ -223,11 +222,8 @@ export async function assessMemoryPressure(): Promise<MemoryVerdict> {
   const psiCalmConfig = readGovernorPsiCalmConfig();
   const snapshot = await readProcMemory();
   const now = Date.now();
-  if (snapshot.psiFullAvg10 != null && snapshot.psiFullAvg10 < psiCalmConfig.readmitAvg10) {
-    psiCalmSinceMs ??= now;
-  } else {
-    psiCalmSinceMs = null;
-  }
+  const psiIsCalm = snapshot.psiFullAvg10 != null
+    && snapshot.psiFullAvg10 < psiCalmConfig.readmitAvg10;
   const previousMode = governorMode;
   const transition = nextGovernorModeWithRunway(
     snapshot.memAvailable,
@@ -241,6 +237,10 @@ export async function assessMemoryPressure(): Promise<MemoryVerdict> {
     governorMode,
   );
   governorMode = transition.mode;
+  const triggerKindChanged = transition.trigger != null
+    && transition.trigger.kind !== governorTrigger?.kind;
+  const pressureStateChanged = governorMode !== 'admitting'
+    && (previousMode !== governorMode || triggerKindChanged);
   if (governorMode === 'admitting') {
     governorTrigger = null;
   } else if (
@@ -248,6 +248,15 @@ export async function assessMemoryPressure(): Promise<MemoryVerdict> {
     && (previousMode === 'admitting' || transition.trigger.kind !== governorTrigger?.kind)
   ) {
     governorTrigger = { ...transition.trigger, at: now };
+  }
+  if (governorMode === 'admitting') {
+    psiCalmSinceMs = null;
+  } else if (pressureStateChanged) {
+    psiCalmSinceMs = psiIsCalm ? now : null;
+  } else if (psiIsCalm) {
+    psiCalmSinceMs ??= now;
+  } else {
+    psiCalmSinceMs = null;
   }
   if (
     governorMode === 'holding'
@@ -257,7 +266,7 @@ export async function assessMemoryPressure(): Promise<MemoryVerdict> {
   ) {
     governorMode = 'admitting';
     governorTrigger = null;
-    psiCalmSinceMs = now;
+    psiCalmSinceMs = null;
   }
   const verdict: MemoryVerdict = {
     band: bandForGovernorMode(governorMode),

--- a/src/lib/cloister/memory-governor.ts
+++ b/src/lib/cloister/memory-governor.ts
@@ -265,6 +265,7 @@ export async function assessMemoryPressure(): Promise<MemoryVerdict> {
     thresholds: { warningBytes: reserves.softBytes, criticalBytes: reserves.hardBytes },
     swapTotalBytes: snapshot.swapTotal,
     swapFreeBytes: snapshot.swapFree,
+    psiSomeAvg10: snapshot.psiSomeAvg10,
     psiFullAvg10: snapshot.psiFullAvg10,
     trigger: governorTrigger,
   };

--- a/src/lib/cloister/memory-governor.ts
+++ b/src/lib/cloister/memory-governor.ts
@@ -13,6 +13,8 @@ import { stopAgentSync } from '../agents/termination.js';
 import {
   getCachedMemoryVerdict,
   setCachedMemoryVerdict,
+  type GovernorTrigger,
+  type GovernorTriggerKind,
   type MemoryPressureBand,
   type MemoryPressureThresholds,
   type MemoryVerdict,
@@ -24,7 +26,7 @@ const GIB = 1024 ** 3;
 
 // Re-exported for backward compatibility — memory-verdict-cache.ts is now the
 // canonical source (it must have no imports of its own to stay cycle-free).
-export type { MemoryPressureBand, MemoryPressureThresholds, MemoryVerdict };
+export type { GovernorTrigger, GovernorTriggerKind, MemoryPressureBand, MemoryPressureThresholds, MemoryVerdict };
 export { getCachedMemoryVerdict };
 
 /**
@@ -76,10 +78,23 @@ export interface GovernorRunwayThresholds {
 }
 
 let governorMode: GovernorMode = 'admitting';
+let governorTrigger: GovernorTrigger | null = null;
+
+export interface GovernorTriggerSeed {
+  kind: GovernorTriggerKind;
+  readingBytes: number;
+  thresholdBytes: number;
+}
+
+export interface GovernorTransition {
+  mode: GovernorMode;
+  trigger: GovernorTriggerSeed | null;
+}
 
 /** Test-only: reset the module-level hysteresis state between test cases. */
 export function resetGovernorModeForTests(): void {
   governorMode = 'admitting';
+  governorTrigger = null;
   setCachedMemoryVerdict(null);
 }
 
@@ -132,9 +147,14 @@ export function nextGovernorModeWithRunway(
   runway: GovernorRunway,
   runwayThresholds: GovernorRunwayThresholds,
   previousMode: GovernorMode,
-): GovernorMode {
+): GovernorTransition {
   const memoryMode = nextGovernorMode(availableBytes, reserves, previousMode);
-  if (runway.swapTotalBytes <= 0) return memoryMode;
+  const memoryTrigger: GovernorTriggerSeed | null = availableBytes < reserves.hardBytes
+    ? { kind: 'hard', readingBytes: availableBytes, thresholdBytes: reserves.hardBytes }
+    : previousMode === 'admitting' && memoryMode === 'holding'
+      ? { kind: 'soft-dip', readingBytes: availableBytes, thresholdBytes: reserves.softBytes }
+      : null;
+  if (runway.swapTotalBytes <= 0) return { mode: memoryMode, trigger: memoryTrigger };
 
   const swapSoftBytes = runway.swapTotalBytes * runwayThresholds.swapSoftFreePercent / 100;
   const swapRecoveryBytes = runway.swapTotalBytes * runwayThresholds.swapRecoveryFreePercent / 100;
@@ -145,7 +165,13 @@ export function nextGovernorModeWithRunway(
     && runway.psiFullAvg10 != null
     && runway.psiFullAvg10 >= runwayThresholds.psiFullShedAvg10;
 
-  if (memoryMode === 'shedding' || psiShed) return 'shedding';
+  if (memoryMode === 'shedding') return { mode: 'shedding', trigger: memoryTrigger };
+  if (psiShed) {
+    return {
+      mode: 'shedding',
+      trigger: { kind: 'swap-psi', readingBytes: runway.swapFreeBytes, thresholdBytes: swapSoftBytes },
+    };
+  }
   // Operator-approved correction (PAN-3485 follow-up, 2026-08-02): swap
   // RESIDENCY is not pressure. Pages swapped during a leak era sit idle for
   // weeks while PSI pins at 0.00 — and holding admissions for them wedges the
@@ -154,8 +180,13 @@ export function nextGovernorModeWithRunway(
   // stall evidence: PSI at/above the shed threshold sheds above; below it we
   // admit. When PSI is UNAVAILABLE we cannot prove safety, so the
   // conservative hold (with its swap-recovery hysteresis) still stands.
-  if (swapLow && runway.psiFullAvg10 == null) return 'holding';
-  return memoryMode;
+  if (swapLow && runway.psiFullAvg10 == null) {
+    return {
+      mode: 'holding',
+      trigger: { kind: 'psi-unavailable', readingBytes: runway.swapFreeBytes, thresholdBytes: swapSoftBytes },
+    };
+  }
+  return { mode: memoryMode, trigger: memoryTrigger };
 }
 
 function bandForGovernorMode(mode: GovernorMode): MemoryPressureBand {
@@ -175,7 +206,8 @@ export async function assessMemoryPressure(): Promise<MemoryVerdict> {
   const reserves = readGovernorReserves();
   const runwayThresholds = readGovernorRunwayThresholds();
   const snapshot = await readProcMemory();
-  governorMode = nextGovernorModeWithRunway(
+  const previousMode = governorMode;
+  const transition = nextGovernorModeWithRunway(
     snapshot.memAvailable,
     reserves,
     {
@@ -186,6 +218,15 @@ export async function assessMemoryPressure(): Promise<MemoryVerdict> {
     runwayThresholds,
     governorMode,
   );
+  governorMode = transition.mode;
+  if (governorMode === 'admitting') {
+    governorTrigger = null;
+  } else if (
+    transition.trigger
+    && (previousMode === 'admitting' || transition.trigger.kind !== governorTrigger?.kind)
+  ) {
+    governorTrigger = { ...transition.trigger, at: Date.now() };
+  }
   const verdict: MemoryVerdict = {
     band: bandForGovernorMode(governorMode),
     availableBytes: snapshot.memAvailable,
@@ -193,6 +234,7 @@ export async function assessMemoryPressure(): Promise<MemoryVerdict> {
     swapTotalBytes: snapshot.swapTotal,
     swapFreeBytes: snapshot.swapFree,
     psiFullAvg10: snapshot.psiFullAvg10,
+    trigger: governorTrigger,
   };
   setCachedMemoryVerdict(verdict);
   return verdict;

--- a/src/lib/cloister/memory-pressure-patrol.ts
+++ b/src/lib/cloister/memory-pressure-patrol.ts
@@ -7,7 +7,7 @@
  * No frontend changes needed — activity.entry already renders in ActivityPanel.
  */
 
-import { MemoryPressureBand, MemoryVerdict, assessMemoryPressure, readGovernorReserves, readGovernorWatchReserveBytes } from './memory-governor.js';
+import { MemoryPressureBand, MemoryVerdict, assessMemoryPressure, readGovernorPsiCalmConfig, readGovernorReserves, readGovernorWatchReserveBytes } from './memory-governor.js';
 import { RuntimeCensus, getRuntimeCensus } from '../runtime-census.js';
 import { emitActivityEntrySync, EmitActivityOptions } from '../activity-logger.js';
 import { logDeaconEventSync } from '../persistent-logger.js';
@@ -41,6 +41,39 @@ function formatGib(bytes: number): string {
   return `${gib.toFixed(1)} GiB`;
 }
 
+function formatTrigger(verdict: MemoryVerdict): string {
+  const trigger = verdict.trigger;
+  if (!trigger) {
+    return verdict.band === 'hard'
+      ? 'Memory critical: the governor entered shedding before trigger details were available.'
+      : 'Overdeck stopped admitting work before trigger details were available.';
+  }
+
+  const since = new Date(trigger.at).toISOString().slice(11, 16);
+  if (trigger.kind === 'soft-dip') {
+    return `Overdeck stopped admitting work at ${since} UTC when available memory dipped to ${formatGib(trigger.readingBytes)}, under the ${formatGib(trigger.thresholdBytes)} soft reserve.`;
+  }
+  if (trigger.kind === 'hard') {
+    return `Overdeck entered critical memory shedding at ${since} UTC when available memory fell to ${formatGib(trigger.readingBytes)}, under the ${formatGib(trigger.thresholdBytes)} hard reserve.`;
+  }
+  if (trigger.kind === 'swap-psi') {
+    return `Overdeck entered critical memory shedding at ${since} UTC when swap free fell to ${formatGib(trigger.readingBytes)}, under the ${formatGib(trigger.thresholdBytes)} swap runway threshold, while memory pressure stalls were active.`;
+  }
+  return `Overdeck stopped admitting work at ${since} UTC when swap free fell to ${formatGib(trigger.readingBytes)}, under the ${formatGib(trigger.thresholdBytes)} swap runway threshold, and memory pressure stall data was unavailable.`;
+}
+
+function formatCalmWindow(windowMs: number): string {
+  const minutes = windowMs / 60_000;
+  return Number.isInteger(minutes) ? `${minutes} minutes` : `${windowMs} ms`;
+}
+
+function formatSheddingExit(verdict: MemoryVerdict, hardBytes: number, recoveryBytes: number): string {
+  if (verdict.trigger?.kind === 'swap-psi') {
+    return `Shedding ends when live memory stalls clear or swap runway recovers. Admissions resume at the ${formatGib(recoveryBytes)} recovery reserve or through the PSI-calm condition.`;
+  }
+  return `Shedding ends when available memory reaches the ${formatGib(hardBytes)} hard reserve. Admissions resume at the ${formatGib(recoveryBytes)} recovery reserve or through the PSI-calm condition.`;
+}
+
 /**
  * Format a multi-line memory details string for activity entry.
  */
@@ -65,6 +98,7 @@ export interface MemoryPressurePatrolDeps {
   readSoftReserveBytes: () => number;
   readHardReserveBytes: () => number;
   readRecoveryReserveBytes: () => number;
+  readPsiCalmConfig: () => { readmitAvg10: number; windowMs: number };
   census: () => Promise<RuntimeCensus>;
   readNewKernelJournal: () => Promise<string>;
   emit: (entry: EmitActivityOptions) => void;
@@ -127,6 +161,7 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
     readSoftReserveBytes: deps.readSoftReserveBytes || (() => readGovernorReserves().softBytes),
     readHardReserveBytes: deps.readHardReserveBytes || (() => readGovernorReserves().hardBytes),
     readRecoveryReserveBytes: deps.readRecoveryReserveBytes || (() => readGovernorReserves().recoveryBytes),
+    readPsiCalmConfig: deps.readPsiCalmConfig || (() => readGovernorPsiCalmConfig()),
     census: deps.census || (() => getRuntimeCensus()),
     readNewKernelJournal: deps.readNewKernelJournal || readNewKernelJournal,
     emit: deps.emit || emitActivityEntrySync,
@@ -137,6 +172,7 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
   const softBytes = d.readSoftReserveBytes();
   const hardBytes = d.readHardReserveBytes();
   const recoveryBytes = d.readRecoveryReserveBytes();
+  const psiCalmConfig = d.readPsiCalmConfig();
   const actions: string[] = [];
 
   // WI-4: Check for new OOM kills in the journal (runs even if level unchanged)
@@ -257,8 +293,8 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
     logDeaconEventSync(`[deacon] ${action}`);
   } else if (level === 'holding') {
     const message =
-      `Memory pressure: Overdeck has stopped admitting work — ${formatGib(verdict.availableBytes)} available is under the ${formatGib(softBytes)} soft reserve. ` +
-      `Queued agent resumes and review/test dispatches will wait until available memory climbs back above the ${formatGib(recoveryBytes)} recovery reserve. ` +
+      `${formatTrigger(verdict)} ${formatGib(verdict.availableBytes)} is available now. ` +
+      `Admissions resume at the ${formatGib(recoveryBytes)} recovery reserve, or at the ${formatGib(softBytes)} soft reserve once memory pressure stalls (PSI full avg10) stay below ${psiCalmConfig.readmitAvg10} for ${formatCalmWindow(psiCalmConfig.windowMs)}. ` +
       `Nothing has been stopped or killed.`;
 
     d.emit({
@@ -275,8 +311,8 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
     logDeaconEventSync(`[deacon] ${action}`);
   } else if (level === 'shedding') {
     const message =
-      `Memory critical — ${formatGib(verdict.availableBytes)} available is under the ${formatGib(hardBytes)} hard reserve. ` +
-      `Overdeck admits nothing and the kernel may start killing processes. ` +
+      `${formatTrigger(verdict)} ${formatGib(verdict.availableBytes)} is available now. ` +
+      `Overdeck admits nothing while shedding is active. ${formatSheddingExit(verdict, hardBytes, recoveryBytes)} ` +
       `Free memory on this host now; automatic shedding is not wired, so Overdeck will not reclaim anything on its own.`;
 
     d.emit({
@@ -293,7 +329,7 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
     logDeaconEventSync(`[deacon] ${action}`);
   } else if (level === 'ok') {
     const message =
-      `Memory pressure cleared — ${formatGib(verdict.availableBytes)} available, above the ${formatGib(watchBytes)} watch reserve. ` +
+      `Memory pressure cleared — ${formatGib(verdict.availableBytes)} available, at or above the ${formatGib(watchBytes)} watch reserve. ` +
       `Overdeck is admitting work again.`;
 
     d.emit({

--- a/src/lib/cloister/memory-pressure-patrol.ts
+++ b/src/lib/cloister/memory-pressure-patrol.ts
@@ -41,6 +41,10 @@ function formatGib(bytes: number): string {
   return `${gib.toFixed(1)} GiB`;
 }
 
+function formatPsi(value: number | null | undefined): string {
+  return value == null ? 'unavailable (pressure stall data not readable)' : value.toFixed(2);
+}
+
 function formatTrigger(verdict: MemoryVerdict): string {
   const trigger = verdict.trigger;
   if (!trigger) {
@@ -78,17 +82,20 @@ function formatSheddingExit(verdict: MemoryVerdict, hardBytes: number, recoveryB
  * Format a multi-line memory details string for activity entry.
  */
 function buildMemoryDetails(
-  availableBytes: number,
+  verdict: MemoryVerdict,
   watchBytes: number,
   softBytes: number,
   hardBytes: number,
   recoveryBytes: number,
 ): string {
-  // For now, just the basic reserve info. We'll add swap and PSI data later in WI-3 and WI-4.
+  const swap = verdict.swapFreeBytes == null || verdict.swapTotalBytes == null
+    ? 'Swap: unavailable'
+    : `Swap: ${formatGib(verdict.swapFreeBytes)} free of ${formatGib(verdict.swapTotalBytes)}`;
   return [
-    `MemAvailable: ${formatGib(availableBytes)}`,
+    `MemAvailable: ${formatGib(verdict.availableBytes)}`,
     `Watch reserve: ${formatGib(watchBytes)} | Soft: ${formatGib(softBytes)} | Hard: ${formatGib(hardBytes)} | Recovery: ${formatGib(recoveryBytes)}`,
-    `Swap free: unavailable | PSI full avg10: unavailable`,
+    swap,
+    `PSI some avg10: ${formatPsi(verdict.psiSomeAvg10)} | full avg10: ${formatPsi(verdict.psiFullAvg10)}`,
   ].join('\n');
 }
 
@@ -202,7 +209,7 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
         source: 'cloister',
         link: '/resources',
         message,
-        details: `OOM kills in Overdeck tree:\n${details}\n\n${buildMemoryDetails(verdict.availableBytes, watchBytes, softBytes, hardBytes, recoveryBytes)}`,
+        details: `OOM kills in Overdeck tree:\n${details}\n\n${buildMemoryDetails(verdict, watchBytes, softBytes, hardBytes, recoveryBytes)}`,
         desktop: true,
       });
 
@@ -228,7 +235,7 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
         source: 'cloister',
         link: '/resources',
         message,
-        details: `OOM kills outside Overdeck:\n${details}\n\n${buildMemoryDetails(verdict.availableBytes, watchBytes, softBytes, hardBytes, recoveryBytes)}`,
+        details: `OOM kills outside Overdeck:\n${details}\n\n${buildMemoryDetails(verdict, watchBytes, softBytes, hardBytes, recoveryBytes)}`,
         desktop: false,
       });
 
@@ -252,7 +259,7 @@ export async function patrolMemoryPressure(deps: Partial<MemoryPressurePatrolDep
 
   // Build details with the base reserves and top consumers
   let details = buildMemoryDetails(
-    verdict.availableBytes,
+    verdict,
     watchBytes,
     softBytes,
     hardBytes,

--- a/src/lib/cloister/memory-verdict-cache.ts
+++ b/src/lib/cloister/memory-verdict-cache.ts
@@ -18,6 +18,15 @@ export interface MemoryPressureThresholds {
   criticalBytes: number;
 }
 
+export type GovernorTriggerKind = 'soft-dip' | 'hard' | 'swap-psi' | 'psi-unavailable';
+
+export interface GovernorTrigger {
+  kind: GovernorTriggerKind;
+  readingBytes: number;
+  thresholdBytes: number;
+  at: number;
+}
+
 export interface MemoryVerdict {
   band: MemoryPressureBand;
   availableBytes: number;
@@ -25,6 +34,7 @@ export interface MemoryVerdict {
   swapTotalBytes?: number;
   swapFreeBytes?: number;
   psiFullAvg10?: number | null;
+  trigger?: GovernorTrigger | null;
 }
 
 let cachedVerdict: MemoryVerdict | null = null;

--- a/src/lib/cloister/memory-verdict-cache.ts
+++ b/src/lib/cloister/memory-verdict-cache.ts
@@ -33,6 +33,7 @@ export interface MemoryVerdict {
   thresholds: MemoryPressureThresholds;
   swapTotalBytes?: number;
   swapFreeBytes?: number;
+  psiSomeAvg10?: number | null;
   psiFullAvg10?: number | null;
   trigger?: GovernorTrigger | null;
 }

--- a/src/lib/config-yaml/defaults.ts
+++ b/src/lib/config-yaml/defaults.ts
@@ -216,6 +216,8 @@ export const DEFAULT_CONFIG: NormalizedConfig = {
     governorSwapSoftFreePercent: 25,
     governorSwapRecoveryFreePercent: 50,
     governorPsiFullShedAvg10: 1,
+    governorPsiCalmReadmitAvg10: 0.05,
+    governorPsiCalmWindowMs: 600_000,
   },
   issues: {
     closedWindowDays: 14,

--- a/src/lib/config-yaml/merge.ts
+++ b/src/lib/config-yaml/merge.ts
@@ -193,6 +193,8 @@ export function mergeConfigs(...configs: (YamlConfig | null)[]): { config: Norma
       governorSwapSoftFreePercent: DEFAULT_CONFIG.resources.governorSwapSoftFreePercent,
       governorSwapRecoveryFreePercent: DEFAULT_CONFIG.resources.governorSwapRecoveryFreePercent,
       governorPsiFullShedAvg10: DEFAULT_CONFIG.resources.governorPsiFullShedAvg10,
+      governorPsiCalmReadmitAvg10: DEFAULT_CONFIG.resources.governorPsiCalmReadmitAvg10,
+      governorPsiCalmWindowMs: DEFAULT_CONFIG.resources.governorPsiCalmWindowMs,
     },
     issues: {
       closedWindowDays: DEFAULT_CONFIG.issues.closedWindowDays,
@@ -685,6 +687,12 @@ export function mergeConfigs(...configs: (YamlConfig | null)[]): { config: Norma
       }
       if (typeof config.resources.governor_psi_full_shed_avg10 === 'number') {
         result.resources.governorPsiFullShedAvg10 = config.resources.governor_psi_full_shed_avg10;
+      }
+      if (typeof config.resources.governor_psi_calm_readmit_avg10 === 'number') {
+        result.resources.governorPsiCalmReadmitAvg10 = config.resources.governor_psi_calm_readmit_avg10;
+      }
+      if (typeof config.resources.governor_psi_calm_window_ms === 'number') {
+        result.resources.governorPsiCalmWindowMs = config.resources.governor_psi_calm_window_ms;
       }
       // PAN-2500: RECOVERY must exceed SOFT or hysteresis can never re-admit.
       // Normalize rather than throw — a misconfigured reserve shouldn't crash config load.

--- a/src/lib/config-yaml/merge.ts
+++ b/src/lib/config-yaml/merge.ts
@@ -688,10 +688,18 @@ export function mergeConfigs(...configs: (YamlConfig | null)[]): { config: Norma
       if (typeof config.resources.governor_psi_full_shed_avg10 === 'number') {
         result.resources.governorPsiFullShedAvg10 = config.resources.governor_psi_full_shed_avg10;
       }
-      if (typeof config.resources.governor_psi_calm_readmit_avg10 === 'number') {
+      if (
+        typeof config.resources.governor_psi_calm_readmit_avg10 === 'number'
+        && Number.isFinite(config.resources.governor_psi_calm_readmit_avg10)
+        && config.resources.governor_psi_calm_readmit_avg10 >= 0
+      ) {
         result.resources.governorPsiCalmReadmitAvg10 = config.resources.governor_psi_calm_readmit_avg10;
       }
-      if (typeof config.resources.governor_psi_calm_window_ms === 'number') {
+      if (
+        typeof config.resources.governor_psi_calm_window_ms === 'number'
+        && Number.isFinite(config.resources.governor_psi_calm_window_ms)
+        && config.resources.governor_psi_calm_window_ms > 0
+      ) {
         result.resources.governorPsiCalmWindowMs = config.resources.governor_psi_calm_window_ms;
       }
       // PAN-2500: RECOVERY must exceed SOFT or hysteresis can never re-admit.

--- a/src/lib/config-yaml/schema.ts
+++ b/src/lib/config-yaml/schema.ts
@@ -429,6 +429,10 @@ export interface ResourcesConfig {
   governor_swap_recovery_free_percent?: number;
   /** PAN-3123: memory PSI full avg10 threshold that permits shedding */
   governor_psi_full_shed_avg10?: number;
+  /** PAN-3754: memory PSI full avg10 below which a held governor can re-admit early */
+  governor_psi_calm_readmit_avg10?: number;
+  /** PAN-3754: continuous calm-PSI duration required for early re-admission */
+  governor_psi_calm_window_ms?: number;
 }
 
 export interface IssuesConfig {
@@ -946,6 +950,8 @@ export interface NormalizedConfig {
     governorSwapSoftFreePercent: number;
     governorSwapRecoveryFreePercent: number;
     governorPsiFullShedAvg10: number;
+    governorPsiCalmReadmitAvg10: number;
+    governorPsiCalmWindowMs: number;
   };
 
   /** Dashboard issue-fetch behavior, normalised (always defined). */

--- a/tests/lib/config-yaml.test.ts
+++ b/tests/lib/config-yaml.test.ts
@@ -261,6 +261,24 @@ api_keys:
       }).config.resources.governorSwapRecoveryFreePercent).toBe(100);
     });
 
+    it('retains calm-PSI defaults for unsafe numeric values', () => {
+      expect(mergeConfigs({
+        resources: { governor_psi_calm_readmit_avg10: 0 },
+      }).config.resources.governorPsiCalmReadmitAvg10).toBe(0);
+
+      for (const governor_psi_calm_readmit_avg10 of [-1, Number.NaN, Number.POSITIVE_INFINITY]) {
+        expect(mergeConfigs({
+          resources: { governor_psi_calm_readmit_avg10 },
+        }).config.resources.governorPsiCalmReadmitAvg10).toBe(0.05);
+      }
+
+      for (const governor_psi_calm_window_ms of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+        expect(mergeConfigs({
+          resources: { governor_psi_calm_window_ms },
+        }).config.resources.governorPsiCalmWindowMs).toBe(600_000);
+      }
+    });
+
     it('normalizes compliance mode with advisory as the default', () => {
       expect(mergeConfigs().config.compliance.mode).toBe('advisory');
       expect(mergeConfigs({ compliance: { mode: 'off' } }).config.compliance.mode).toBe('off');

--- a/tests/lib/config-yaml.test.ts
+++ b/tests/lib/config-yaml.test.ts
@@ -231,6 +231,8 @@ api_keys:
         governorSwapSoftFreePercent: 25,
         governorSwapRecoveryFreePercent: 50,
         governorPsiFullShedAvg10: 1,
+        governorPsiCalmReadmitAvg10: 0.05,
+        governorPsiCalmWindowMs: 600_000,
       });
     });
 
@@ -240,11 +242,15 @@ api_keys:
           governor_swap_soft_free_percent: 30,
           governor_swap_recovery_free_percent: 60,
           governor_psi_full_shed_avg10: 2.5,
+          governor_psi_calm_readmit_avg10: 0.02,
+          governor_psi_calm_window_ms: 300_000,
         },
       }).config.resources).toMatchObject({
         governorSwapSoftFreePercent: 30,
         governorSwapRecoveryFreePercent: 60,
         governorPsiFullShedAvg10: 2.5,
+        governorPsiCalmReadmitAvg10: 0.02,
+        governorPsiCalmWindowMs: 300_000,
       });
 
       expect(mergeConfigs({

--- a/tests/unit/lib/cloister/memory-governor.test.ts
+++ b/tests/unit/lib/cloister/memory-governor.test.ts
@@ -93,6 +93,7 @@ function procMemory(
   overrides: Partial<{
     swapTotal: number;
     swapFree: number;
+    psiSomeAvg10: number | null;
     psiFullAvg10: number | null;
   }> = {},
 ) {
@@ -100,6 +101,7 @@ function procMemory(
     memAvailable,
     swapTotal: 8 * GIB,
     swapFree: 8 * GIB,
+    psiSomeAvg10: 0,
     psiFullAvg10: 0,
     ...overrides,
   };
@@ -406,12 +408,14 @@ describe('assessMemoryPressure', () => {
   it('returns swap and PSI evidence in the verdict', async () => {
     readProcMemoryMock.mockResolvedValue(procMemory(20 * GIB, {
       swapFree: 2 * GIB,
+      psiSomeAvg10: 0.5,
       psiFullAvg10: 0.25,
     }));
 
     await expect(assessMemoryPressure()).resolves.toMatchObject({
       swapTotalBytes: 8 * GIB,
       swapFreeBytes: 2 * GIB,
+      psiSomeAvg10: 0.5,
       psiFullAvg10: 0.25,
     });
   });

--- a/tests/unit/lib/cloister/memory-governor.test.ts
+++ b/tests/unit/lib/cloister/memory-governor.test.ts
@@ -335,6 +335,43 @@ describe('assessMemoryPressure', () => {
     }
   });
 
+  it('does not count calm PSI time accumulated before a new pressure hold', async () => {
+    vi.useFakeTimers();
+    try {
+      readProcMemoryMock.mockResolvedValueOnce(procMemory(20 * GIB));
+      expect((await assessMemoryPressure()).band).toBe('ok');
+      await vi.advanceTimersByTimeAsync(600_000);
+
+      readProcMemoryMock.mockResolvedValueOnce(procMemory(7 * GIB));
+      expect((await assessMemoryPressure()).band).toBe('soft');
+      readProcMemoryMock.mockResolvedValueOnce(procMemory(9 * GIB));
+      expect((await assessMemoryPressure()).band).toBe('soft');
+
+      await vi.advanceTimersByTimeAsync(600_000);
+      readProcMemoryMock.mockResolvedValue(procMemory(9 * GIB));
+      expect((await assessMemoryPressure()).band).toBe('ok');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('records the active swap recovery threshold after admissions are already held', async () => {
+    readProcMemoryMock.mockResolvedValueOnce(procMemory(7 * GIB));
+    expect((await assessMemoryPressure()).trigger?.kind).toBe('soft-dip');
+
+    readProcMemoryMock.mockResolvedValue(procMemory(20 * GIB, {
+      swapFree: 3 * GIB,
+      psiFullAvg10: 2,
+    }));
+    await expect(assessMemoryPressure()).resolves.toMatchObject({
+      trigger: {
+        kind: 'swap-psi',
+        readingBytes: 3 * GIB,
+        thresholdBytes: 4 * GIB,
+      },
+    });
+  });
+
   it('admits when swap is full but PSI shows no stalls (swap residency is not pressure)', async () => {
     // Operator-approved correction (PAN-3485 follow-up): full-but-idle swap
     // with PSI 0.00 must NOT hold admissions — pages swapped during a leak era

--- a/tests/unit/lib/cloister/memory-governor.test.ts
+++ b/tests/unit/lib/cloister/memory-governor.test.ts
@@ -84,6 +84,8 @@ const GOVERNOR_RESOURCES = {
   governorSwapSoftFreePercent: 25,
   governorSwapRecoveryFreePercent: 50,
   governorPsiFullShedAvg10: 1,
+  governorPsiCalmReadmitAvg10: 0.05,
+  governorPsiCalmWindowMs: 600_000,
 };
 
 function procMemory(
@@ -276,6 +278,59 @@ describe('assessMemoryPressure', () => {
 
     readProcMemoryMock.mockResolvedValue(procMemory(13 * GIB));
     expect((await assessMemoryPressure()).trigger).toBeNull();
+  });
+
+  it('re-admits above the soft reserve after PSI stays calm for the configured window', async () => {
+    vi.useFakeTimers();
+    try {
+      readProcMemoryMock.mockResolvedValueOnce(procMemory(7 * GIB));
+      expect((await assessMemoryPressure()).band).toBe('soft');
+
+      await vi.advanceTimersByTimeAsync(600_000);
+      readProcMemoryMock.mockResolvedValue(procMemory(9 * GIB));
+      await expect(assessMemoryPressure()).resolves.toMatchObject({ band: 'ok', trigger: null });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stays holding below recovery while PSI is not calm', async () => {
+    vi.useFakeTimers();
+    try {
+      readProcMemoryMock.mockResolvedValueOnce(procMemory(7 * GIB, { psiFullAvg10: 0.3 }));
+      expect((await assessMemoryPressure()).band).toBe('soft');
+
+      await vi.advanceTimersByTimeAsync(600_000);
+      readProcMemoryMock.mockResolvedValue(procMemory(9 * GIB, { psiFullAvg10: 0.3 }));
+      expect((await assessMemoryPressure()).band).toBe('soft');
+
+      readProcMemoryMock.mockResolvedValue(procMemory(13 * GIB, { psiFullAvg10: 0.3 }));
+      expect((await assessMemoryPressure()).band).toBe('ok');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('requires a fresh calm window after an early re-admit and a second dip', async () => {
+    vi.useFakeTimers();
+    try {
+      readProcMemoryMock.mockResolvedValueOnce(procMemory(7 * GIB));
+      expect((await assessMemoryPressure()).band).toBe('soft');
+      await vi.advanceTimersByTimeAsync(600_000);
+      readProcMemoryMock.mockResolvedValueOnce(procMemory(9 * GIB));
+      expect((await assessMemoryPressure()).band).toBe('ok');
+
+      readProcMemoryMock.mockResolvedValueOnce(procMemory(7 * GIB));
+      expect((await assessMemoryPressure()).band).toBe('soft');
+      await vi.advanceTimersByTimeAsync(599_999);
+      readProcMemoryMock.mockResolvedValueOnce(procMemory(9 * GIB));
+      expect((await assessMemoryPressure()).band).toBe('soft');
+      await vi.advanceTimersByTimeAsync(1);
+      readProcMemoryMock.mockResolvedValue(procMemory(9 * GIB));
+      expect((await assessMemoryPressure()).band).toBe('ok');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('admits when swap is full but PSI shows no stalls (swap residency is not pressure)', async () => {

--- a/tests/unit/lib/cloister/memory-governor.test.ts
+++ b/tests/unit/lib/cloister/memory-governor.test.ts
@@ -202,6 +202,82 @@ describe('assessMemoryPressure', () => {
     expect((await assessMemoryPressure()).band).toBe('ok');
   });
 
+  it('records the MemAvailable reading that triggered a soft hold', async () => {
+    readProcMemoryMock.mockResolvedValue(procMemory(7 * GIB));
+
+    await expect(assessMemoryPressure()).resolves.toMatchObject({
+      trigger: {
+        kind: 'soft-dip',
+        readingBytes: 7 * GIB,
+        thresholdBytes: 8 * GIB,
+        at: expect.any(Number),
+      },
+    });
+  });
+
+  it('records the MemAvailable reading that triggered hard shedding', async () => {
+    readProcMemoryMock.mockResolvedValue(procMemory(2 * GIB));
+
+    await expect(assessMemoryPressure()).resolves.toMatchObject({
+      trigger: {
+        kind: 'hard',
+        readingBytes: 2 * GIB,
+        thresholdBytes: 4 * GIB,
+        at: expect.any(Number),
+      },
+    });
+  });
+
+  it('records the swap reading that triggered PSI-backed shedding', async () => {
+    readProcMemoryMock.mockResolvedValue(procMemory(20 * GIB, {
+      swapFree: 1 * GIB,
+      psiFullAvg10: 2,
+    }));
+
+    await expect(assessMemoryPressure()).resolves.toMatchObject({
+      trigger: {
+        kind: 'swap-psi',
+        readingBytes: 1 * GIB,
+        thresholdBytes: 2 * GIB,
+        at: expect.any(Number),
+      },
+    });
+  });
+
+  it('records the swap reading that triggered a hold when PSI is unavailable', async () => {
+    readProcMemoryMock.mockResolvedValue(procMemory(20 * GIB, {
+      swapFree: 1 * GIB,
+      psiFullAvg10: null,
+    }));
+
+    await expect(assessMemoryPressure()).resolves.toMatchObject({
+      trigger: {
+        kind: 'psi-unavailable',
+        readingBytes: 1 * GIB,
+        thresholdBytes: 2 * GIB,
+        at: expect.any(Number),
+      },
+    });
+  });
+
+  it('updates trigger provenance when the trigger kind changes during a hold', async () => {
+    readProcMemoryMock.mockResolvedValueOnce(procMemory(7 * GIB));
+    expect((await assessMemoryPressure()).trigger?.kind).toBe('soft-dip');
+
+    readProcMemoryMock.mockResolvedValue(procMemory(2 * GIB));
+    await expect(assessMemoryPressure()).resolves.toMatchObject({
+      trigger: { kind: 'hard', readingBytes: 2 * GIB, thresholdBytes: 4 * GIB },
+    });
+  });
+
+  it('clears trigger provenance when the governor re-admits', async () => {
+    readProcMemoryMock.mockResolvedValueOnce(procMemory(7 * GIB));
+    expect((await assessMemoryPressure()).trigger?.kind).toBe('soft-dip');
+
+    readProcMemoryMock.mockResolvedValue(procMemory(13 * GIB));
+    expect((await assessMemoryPressure()).trigger).toBeNull();
+  });
+
   it('admits when swap is full but PSI shows no stalls (swap residency is not pressure)', async () => {
     // Operator-approved correction (PAN-3485 follow-up): full-but-idle swap
     // with PSI 0.00 must NOT hold admissions — pages swapped during a leak era
@@ -290,6 +366,7 @@ describe('assessMemoryPressure', () => {
     readProcMemoryMock.mockResolvedValue(procMemory(2 * GIB));
     const verdict = await assessMemoryPressure();
     expect(getCachedMemoryVerdict()).toEqual(verdict);
+    expect(getCachedMemoryVerdict()?.trigger).toEqual(verdict.trigger);
   });
 });
 

--- a/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
+++ b/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
@@ -319,6 +319,55 @@ describe('memory-pressure-patrol', () => {
       expect(details).toContain('MemAvailable');
       expect(details).toContain('Watch reserve');
     });
+
+    it('prints real swap and PSI readings in the details block', async () => {
+      const emitted: any[] = [];
+      await patrolMemoryPressure({
+        assess: async () => ({
+          band: 'ok',
+          availableBytes: 20 * GIB,
+          swapFreeBytes: 0,
+          swapTotalBytes: 8 * GIB,
+          psiSomeAvg10: 0,
+          psiFullAvg10: 0,
+        }),
+        readWatchReserveBytes: () => 12 * GIB,
+        readSoftReserveBytes: () => 8 * GIB,
+        readHardReserveBytes: () => 4 * GIB,
+        readRecoveryReserveBytes: () => 16 * GIB,
+        readPsiCalmConfig: () => ({ readmitAvg10: 0.05, windowMs: 600_000 }),
+        emit: (entry) => emitted.push(entry),
+      });
+
+      expect(emitted[0].details).toContain('Swap: 0.0 GiB free of 8.0 GiB');
+      expect(emitted[0].details).toContain('PSI some avg10: 0.00 | full avg10: 0.00');
+      expect(emitted[0].details).not.toContain('Swap free: unavailable');
+    });
+
+    it('labels only unreadable PSI values unavailable while preserving swap readings', async () => {
+      const emitted: any[] = [];
+      await patrolMemoryPressure({
+        assess: async () => ({
+          band: 'ok',
+          availableBytes: 20 * GIB,
+          swapFreeBytes: 2 * GIB,
+          swapTotalBytes: 8 * GIB,
+          psiSomeAvg10: 0.12,
+          psiFullAvg10: null,
+        }),
+        readWatchReserveBytes: () => 12 * GIB,
+        readSoftReserveBytes: () => 8 * GIB,
+        readHardReserveBytes: () => 4 * GIB,
+        readRecoveryReserveBytes: () => 16 * GIB,
+        readPsiCalmConfig: () => ({ readmitAvg10: 0.05, windowMs: 600_000 }),
+        emit: (entry) => emitted.push(entry),
+      });
+
+      expect(emitted[0].details).toContain('Swap: 2.0 GiB free of 8.0 GiB');
+      expect(emitted[0].details).toContain(
+        'PSI some avg10: 0.12 | full avg10: unavailable (pressure stall data not readable)',
+      );
+    });
   });
 
   describe('topMemoryConsumers', () => {

--- a/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
+++ b/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
@@ -46,6 +46,7 @@ describe('memory-pressure-patrol', () => {
         readSoftReserveBytes: () => 8 * GIB,
         readHardReserveBytes: () => 4 * GIB,
         readRecoveryReserveBytes: () => 16 * GIB,
+        readPsiCalmConfig: () => ({ readmitAvg10: 0.05, windowMs: 600_000 }),
         emit: (entry: object) => emitted.push(entry),
       };
 
@@ -77,6 +78,7 @@ describe('memory-pressure-patrol', () => {
         readSoftReserveBytes: () => 8 * GIB,
         readHardReserveBytes: () => 4 * GIB,
         readRecoveryReserveBytes: () => 16 * GIB,
+        readPsiCalmConfig: () => ({ readmitAvg10: 0.05, windowMs: 600_000 }),
         emit: (entry: object) => emitted.push(entry),
       };
 
@@ -104,6 +106,7 @@ describe('memory-pressure-patrol', () => {
         readSoftReserveBytes: () => 8 * GIB,
         readHardReserveBytes: () => 4 * GIB,
         readRecoveryReserveBytes: () => 16 * GIB,
+        readPsiCalmConfig: () => ({ readmitAvg10: 0.05, windowMs: 600_000 }),
         emit: (entry: object) => emitted.push(entry),
       };
 
@@ -117,6 +120,33 @@ describe('memory-pressure-patrol', () => {
       expect((emitted[0] as any).message).toContain('stopped admitting');
       expect((emitted[0] as any).message).toContain('recovery reserve');
       expect(actions).toHaveLength(1);
+    });
+
+    it('explains a hold from its stored trigger, current reading, and both exit conditions', async () => {
+      const emitted: any[] = [];
+      const triggerAt = Date.UTC(2026, 0, 1, 14, 22);
+      const verdict: MemoryVerdict = {
+        band: 'soft',
+        availableBytes: 12.5 * GIB,
+        trigger: { kind: 'soft-dip', readingBytes: 7 * GIB, thresholdBytes: 8 * GIB, at: triggerAt },
+      };
+
+      await patrolMemoryPressure({
+        assess: async () => verdict,
+        readWatchReserveBytes: () => 14 * GIB,
+        readSoftReserveBytes: () => 8 * GIB,
+        readHardReserveBytes: () => 4 * GIB,
+        readRecoveryReserveBytes: () => 16 * GIB,
+        readPsiCalmConfig: () => ({ readmitAvg10: 0.05, windowMs: 600_000 }),
+        emit: (entry) => emitted.push(entry),
+      });
+
+      expect(emitted[0].message).toContain('14:22 UTC');
+      expect(emitted[0].message).toContain('dipped to 7.0 GiB, under the 8.0 GiB soft reserve');
+      expect(emitted[0].message).toContain('12.5 GiB is available now');
+      expect(emitted[0].message).toContain('16.0 GiB recovery reserve');
+      expect(emitted[0].message).toContain('8.0 GiB soft reserve');
+      expect(emitted[0].message).toContain('below 0.05 for 10 minutes');
     });
 
     it('emits an error-level entry for hard band (shedding)', async () => {
@@ -133,6 +163,7 @@ describe('memory-pressure-patrol', () => {
         readSoftReserveBytes: () => 8 * GIB,
         readHardReserveBytes: () => 4 * GIB,
         readRecoveryReserveBytes: () => 16 * GIB,
+        readPsiCalmConfig: () => ({ readmitAvg10: 0.05, windowMs: 600_000 }),
         emit: (entry: object) => emitted.push(entry),
       };
 
@@ -145,6 +176,77 @@ describe('memory-pressure-patrol', () => {
       });
       expect((emitted[0] as any).message).toContain('critical');
       expect(actions).toHaveLength(1);
+    });
+
+    it('attributes swap/PSI shedding without claiming current memory is below hard', async () => {
+      const emitted: any[] = [];
+      const verdict: MemoryVerdict = {
+        band: 'hard',
+        availableBytes: 12.5 * GIB,
+        trigger: {
+          kind: 'swap-psi',
+          readingBytes: 1 * GIB,
+          thresholdBytes: 2 * GIB,
+          at: Date.UTC(2026, 0, 1, 14, 22),
+        },
+      };
+
+      await patrolMemoryPressure({
+        assess: async () => verdict,
+        readWatchReserveBytes: () => 14 * GIB,
+        readSoftReserveBytes: () => 8 * GIB,
+        readHardReserveBytes: () => 4 * GIB,
+        readRecoveryReserveBytes: () => 16 * GIB,
+        readPsiCalmConfig: () => ({ readmitAvg10: 0.05, windowMs: 600_000 }),
+        emit: (entry) => emitted.push(entry),
+      });
+
+      expect(emitted[0].message).toContain('swap free fell to 1.0 GiB');
+      expect(emitted[0].message).toContain('memory pressure stalls were active');
+      expect(emitted[0].message).not.toContain('12.5 GiB available is under the 4.0 GiB hard reserve');
+    });
+
+    it('keeps every availability-versus-reserve claim numerically true across bands and triggers', async () => {
+      const triggerCases = [
+        { kind: 'soft-dip' as const, readingBytes: 7 * GIB, thresholdBytes: 8 * GIB },
+        { kind: 'hard' as const, readingBytes: 3 * GIB, thresholdBytes: 4 * GIB },
+        { kind: 'swap-psi' as const, readingBytes: 1 * GIB, thresholdBytes: 2 * GIB },
+        { kind: 'psi-unavailable' as const, readingBytes: 1 * GIB, thresholdBytes: 2 * GIB },
+      ];
+      const bands: MemoryPressureBand[] = ['ok', 'soft', 'hard'];
+
+      for (const band of bands) {
+        for (const trigger of triggerCases) {
+          for (const availableGib of [3, 6, 10, 20]) {
+            __resetMemoryPressurePatrolState();
+            const emitted: any[] = [];
+            await patrolMemoryPressure({
+              assess: async () => ({
+                band,
+                availableBytes: availableGib * GIB,
+                trigger: { ...trigger, at: Date.UTC(2026, 0, 1, 14, 22) },
+              }),
+              readWatchReserveBytes: () => 12 * GIB,
+              readSoftReserveBytes: () => 8 * GIB,
+              readHardReserveBytes: () => 4 * GIB,
+              readRecoveryReserveBytes: () => 16 * GIB,
+              readPsiCalmConfig: () => ({ readmitAvg10: 0.05, windowMs: 600_000 }),
+              emit: (entry) => emitted.push(entry),
+            });
+
+            const message = emitted[0].message as string;
+            for (const match of message.matchAll(/([\d.]+) GiB available, below the ([\d.]+) GiB/g)) {
+              expect(Number(match[1])).toBeLessThan(Number(match[2]));
+            }
+            for (const match of message.matchAll(/([\d.]+) GiB available, at or above the ([\d.]+) GiB/g)) {
+              expect(Number(match[1])).toBeGreaterThanOrEqual(Number(match[2]));
+            }
+            for (const match of message.matchAll(/(?:dipped|fell) to ([\d.]+) GiB, under the ([\d.]+) GiB/g)) {
+              expect(Number(match[1])).toBeLessThan(Number(match[2]));
+            }
+          }
+        }
+      }
     });
 
     it('emits an info-level entry when recovering from watch to ok', async () => {
@@ -161,6 +263,7 @@ describe('memory-pressure-patrol', () => {
         readSoftReserveBytes: () => 8 * GIB,
         readHardReserveBytes: () => 4 * GIB,
         readRecoveryReserveBytes: () => 16 * GIB,
+        readPsiCalmConfig: () => ({ readmitAvg10: 0.05, windowMs: 600_000 }),
         emit: (entry: object) => emitted.push(entry),
       };
 
@@ -204,6 +307,7 @@ describe('memory-pressure-patrol', () => {
         readSoftReserveBytes: () => 8 * GIB,
         readHardReserveBytes: () => 4 * GIB,
         readRecoveryReserveBytes: () => 16 * GIB,
+        readPsiCalmConfig: () => ({ readmitAvg10: 0.05, windowMs: 600_000 }),
         emit: (entry: object) => emitted.push(entry),
       };
 

--- a/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
+++ b/tests/unit/lib/cloister/memory-pressure-patrol.test.ts
@@ -3,6 +3,7 @@ import { memoryFeedLevel, patrolMemoryPressure, __resetMemoryPressurePatrolState
 import type { MemoryVerdict, MemoryPressureBand } from '../../../../src/lib/cloister/memory-governor.js';
 
 const GIB = 1024 ** 3;
+const THRESHOLDS = { warningBytes: 8 * GIB, criticalBytes: 4 * GIB };
 
 describe('memory-pressure-patrol', () => {
   beforeEach(() => {
@@ -38,6 +39,7 @@ describe('memory-pressure-patrol', () => {
       const mockVerdict: MemoryVerdict = {
         band: 'ok' as const,
         availableBytes: 10 * GIB,
+        thresholds: THRESHOLDS,
       };
 
       const deps = {
@@ -70,6 +72,7 @@ describe('memory-pressure-patrol', () => {
       const mockVerdict: MemoryVerdict = {
         band: 'ok' as const,
         availableBytes: 10 * GIB,
+        thresholds: THRESHOLDS,
       };
 
       const deps = {
@@ -98,6 +101,7 @@ describe('memory-pressure-patrol', () => {
       const mockVerdict: MemoryVerdict = {
         band: 'soft' as const,
         availableBytes: 7 * GIB,
+        thresholds: THRESHOLDS,
       };
 
       const deps = {
@@ -128,6 +132,7 @@ describe('memory-pressure-patrol', () => {
       const verdict: MemoryVerdict = {
         band: 'soft',
         availableBytes: 12.5 * GIB,
+        thresholds: THRESHOLDS,
         trigger: { kind: 'soft-dip', readingBytes: 7 * GIB, thresholdBytes: 8 * GIB, at: triggerAt },
       };
 
@@ -155,6 +160,7 @@ describe('memory-pressure-patrol', () => {
       const mockVerdict: MemoryVerdict = {
         band: 'hard' as const,
         availableBytes: 3 * GIB,
+        thresholds: THRESHOLDS,
       };
 
       const deps = {
@@ -183,6 +189,7 @@ describe('memory-pressure-patrol', () => {
       const verdict: MemoryVerdict = {
         band: 'hard',
         availableBytes: 12.5 * GIB,
+        thresholds: THRESHOLDS,
         trigger: {
           kind: 'swap-psi',
           readingBytes: 1 * GIB,
@@ -224,6 +231,7 @@ describe('memory-pressure-patrol', () => {
               assess: async () => ({
                 band,
                 availableBytes: availableGib * GIB,
+                thresholds: THRESHOLDS,
                 trigger: { ...trigger, at: Date.UTC(2026, 0, 1, 14, 22) },
               }),
               readWatchReserveBytes: () => 12 * GIB,
@@ -255,6 +263,7 @@ describe('memory-pressure-patrol', () => {
       const mockVerdict: MemoryVerdict = {
         band: 'ok' as const,
         availableBytes: 10 * GIB,
+        thresholds: THRESHOLDS,
       };
 
       const deps = {
@@ -277,6 +286,7 @@ describe('memory-pressure-patrol', () => {
       const recoverVerdict: MemoryVerdict = {
         band: 'ok' as const,
         availableBytes: 15 * GIB,
+        thresholds: THRESHOLDS,
       };
       const recoverDeps = {
         ...deps,
@@ -299,6 +309,7 @@ describe('memory-pressure-patrol', () => {
       const mockVerdict: MemoryVerdict = {
         band: 'ok' as const,
         availableBytes: 10 * GIB,
+        thresholds: THRESHOLDS,
       };
 
       const deps = {
@@ -326,6 +337,7 @@ describe('memory-pressure-patrol', () => {
         assess: async () => ({
           band: 'ok',
           availableBytes: 20 * GIB,
+          thresholds: THRESHOLDS,
           swapFreeBytes: 0,
           swapTotalBytes: 8 * GIB,
           psiSomeAvg10: 0,
@@ -350,6 +362,7 @@ describe('memory-pressure-patrol', () => {
         assess: async () => ({
           band: 'ok',
           availableBytes: 20 * GIB,
+          thresholds: THRESHOLDS,
           swapFreeBytes: 2 * GIB,
           swapTotalBytes: 8 * GIB,
           psiSomeAvg10: 0.12,


### PR DESCRIPTION
**Issue:** #3754

## Acceptance Criteria

- [ ] Record non-admitting trigger provenance and expose it on MemoryVerdict
- [ ] Add PSI-calm early re-admit with config keys and re-arm
- [ ] Rewrite patrol hold/shed messages to print stored trigger plus current reading
- [ ] Print real swap and PSI values in the patrol details block
- [ ] Document PSI-calm early re-admit, new config keys, and message format in RESOURCE-GOVERNOR.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PSI-based memory recovery, allowing earlier re-admission after sustained calm conditions.
  * Added configurable PSI recovery thresholds and calm-window duration.
  * Memory status messages now identify triggering conditions and include current memory, swap, and PSI readings.
  * Recovery messaging now explains readmission requirements and monitoring thresholds.

* **Documentation**
  * Updated resource governor documentation with the new recovery path and configuration options.

* **Tests**
  * Expanded coverage for PSI recovery, trigger attribution, configuration, and status messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->