### PR TITLE
PAN-3752

### DIFF
--- a/docs/DASHBOARD-ARCHITECTURE.md
+++ b/docs/DASHBOARD-ARCHITECTURE.md
@@ -46,7 +46,9 @@ The dashboard server uses **Effect.js** for HTTP routes and structured RPC, plus
 **DB job worker lanes:**
 - The `read` lane handles interactive lookups, the `long` lane handles bulk scans and
   reconciliation, and the `semantic` lane isolates embedding and semantic-search work.
-  This separation prevents a bulk job from delaying an operator-facing read.
+  The `parse` lane runs `parseTranscriptSnapshot`. Transcript parsing is CPU-bound and
+  can take seconds, so its own lane cannot block interactive reads or wait behind bulk
+  sweeps.
 - Worker implementations live in `src/dashboard/server/services/dashboard-db-worker.ts`.
   Add each new operation to both `dashboard-db-task.ts` and the worker dispatch table so
   the main thread and worker remain type-safe.
@@ -58,6 +60,10 @@ The dashboard server uses **Effect.js** for HTTP routes and structured RPC, plus
   acknowledges each batch before the worker continues its single-pass scan. This limits
   transfer memory without repeated parsing while preserving EventBus publication and
   durable skip-cache updates.
+- `subscribeConversationMessages` resolves transcript paths on the main thread, sends
+  full parses through `parseTranscriptSnapshot`, and emits the unchanged result after
+  the parse worker responds. File watching, debounce state, and event emission remain
+  on the main thread.
 
 **Issue views:** Rail, cockpit, and console issue surfaces share the kit documented in
 `docs/ISSUE-VIEW.md`. Route new issue sections through `IssueViewModel`, the shared

--- a/scripts/lint-skills.sh
+++ b/scripts/lint-skills.sh
@@ -6,6 +6,7 @@ cd "$(dirname "$0")/.."
 python3 - <<'PY'
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
@@ -32,7 +33,9 @@ def run_pan(*args: str) -> str:
         return cached
 
     last: subprocess.CompletedProcess[str] | None = None
-    for attempt in range(5):
+    deadline = time.monotonic() + float(os.environ.get("PAN_SKILL_LINT_RETRY_SECONDS", "120"))
+    attempt = 0
+    while True:
         last = subprocess.run(
             [*LOCAL_PAN, *args],
             cwd=ROOT,
@@ -45,11 +48,13 @@ def run_pan(*args: str) -> str:
             with RUN_PAN_CACHE_LOCK:
                 RUN_PAN_CACHE[key] = last.stdout
             return last.stdout
-        # The CLI help smoke tests run immediately after tsdown rewrites dist/.
-        # Give the filesystem/module loader a short settle window before treating
-        # a command as genuinely broken.
-        if attempt < 4:
-            time.sleep(0.2 * (attempt + 1))
+        # Verification can run another build-heavy specialist against this workspace.
+        # That build cleans and rewrites dist/ while these CLI help probes are active.
+        # Wait through a complete competing build before treating the command as broken.
+        if time.monotonic() >= deadline:
+            break
+        attempt += 1
+        time.sleep(min(2.0, 0.2 * attempt))
 
     assert last is not None
     raise subprocess.CalledProcessError(last.returncode, last.args, output=last.stdout)

--- a/src/dashboard/server/services/dashboard-db-task.ts
+++ b/src/dashboard/server/services/dashboard-db-task.ts
@@ -111,6 +111,7 @@ const COALESCED_OPERATIONS = new Set<DashboardDbOperation>([
   'embedSessions',
   'searchSessionsSemantic',
   'listSubstrateBugWeights',
+  'parseTranscriptSnapshot',
 ]);
 
 const workers: Record<WorkerLane, Worker | null> = { read: null, long: null, semantic: null, parse: null };
@@ -346,15 +347,25 @@ export function runDashboardDbJob<T>(
   payload?: unknown,
   onProgress?: (progress: unknown) => void | Promise<void>,
 ): Promise<T> {
-  if (import.meta.url.endsWith('.ts') && process.env['VITEST']) {
-    return runInline(operation, payload, onProgress) as Promise<T>;
-  }
-
   const key = coalescingKey(operation, payload);
   const existing = key ? sharedJobs.get(key) : undefined;
   if (existing) {
     if (onProgress) existing.progressListeners.add(onProgress);
     return existing.promise as Promise<T>;
+  }
+
+  if (import.meta.url.endsWith('.ts') && process.env['VITEST']) {
+    const progressListeners = new Set<ProgressHandler>();
+    if (onProgress) progressListeners.add(onProgress);
+    const promise = runInline(operation, payload, onProgress) as Promise<T>;
+    if (key) {
+      sharedJobs.set(key, { lane: workerLane(operation), promise, progressListeners });
+      promise.then(
+        () => sharedJobs.delete(key),
+        () => sharedJobs.delete(key),
+      );
+    }
+    return promise;
   }
 
   if (pending.size >= MAX_PENDING_JOBS) {

--- a/src/dashboard/server/services/dashboard-db-task.ts
+++ b/src/dashboard/server/services/dashboard-db-task.ts
@@ -95,6 +95,7 @@ interface WorkerResponse {
   progressSeq?: number;
   startedAt?: number;
   finishedAt?: number;
+  bytes?: number;
   error?: {
     name?: string;
     message?: string;
@@ -127,9 +128,11 @@ export function formatSlowJobLine(input: {
   waitMs: number;
   runMs: number;
   depth: number;
+  bytes?: number;
 }): string | null {
   if (input.waitMs <= 1_000 && input.runMs <= 1_000) return null;
-  return `[db-jobs] slow: op=${input.op} lane=${input.lane} waitMs=${input.waitMs} runMs=${input.runMs} depth=${input.depth}`;
+  const bytes = input.bytes === undefined ? '' : ` bytes=${input.bytes}`;
+  return `[db-jobs] slow: op=${input.op} lane=${input.lane} waitMs=${input.waitMs} runMs=${input.runMs} depth=${input.depth}${bytes}`;
 }
 
 function workerScriptUrl(): URL {
@@ -221,6 +224,7 @@ function getWorker(lane: WorkerLane): Worker {
         waitMs: message.startedAt - job.enqueuedAt,
         runMs: message.finishedAt - message.startedAt,
         depth: [...pending.values()].filter(pendingJob => pendingJob.lane === job.lane).length,
+        bytes: message.bytes,
       });
       if (line) console.warn(line);
     }
@@ -333,12 +337,16 @@ async function runInline(
   onProgress?: (progress: unknown) => void | Promise<void>,
 ): Promise<unknown> {
   const startedAt = Date.now();
+  let bytes: number | undefined;
   try {
-    return await executeInline(operation, payload, onProgress);
+    const result = await executeInline(operation, payload, onProgress);
+    if (operation === 'parseTranscriptSnapshot') bytes = (result as ParseResult).byteOffset;
+    return result;
   } finally {
     const line = formatSlowJobLine({
       op: operation, lane: workerLane(operation), waitMs: 0,
       runMs: Date.now() - startedAt, depth: 0,
+      bytes,
     });
     if (line) console.warn(line);
   }

--- a/src/dashboard/server/services/dashboard-db-task.ts
+++ b/src/dashboard/server/services/dashboard-db-task.ts
@@ -24,6 +24,12 @@ import type { EmbedSessionsOptions } from '../../../lib/conversations/embeddings
 import { listSubstrateBugWeights } from '../../../lib/overdeck/substrate-bug-weights-service.js';
 import { collectCodexCostEvents } from '../../../lib/overdeck/cost.js';
 import { collectPiCostEvents } from '../../../lib/costs/reconciler.js';
+import { parseAcpConversationMessages } from './acp-conversation-parser.js';
+import { parseCodexConversationMessages } from './codex-conversation-parser.js';
+import { parseKimiConversationMessages } from './kimi-conversation-parser.js';
+import { parseOhmypiConversationMessages } from './ohmypi-conversation-parser.js';
+import { parsePiConversationMessages } from './pi-conversation-parser.js';
+import type { ParseResult } from './conversation-service.js';
 
 export type DashboardDbOperation =
   | 'getDiscoveredStats'
@@ -45,10 +51,22 @@ export type DashboardDbOperation =
   | 'getArtifactBySlug'
   | 'listArtifactsForWorkspaceOrIssue'
   | 'unshareArtifactBySlug'
+  | 'parseTranscriptSnapshot'
   | 'costReconcileSweep';
 
 type ProgressHandler = (progress: unknown) => void | Promise<void>;
-export type WorkerLane = 'read' | 'long' | 'semantic';
+export type WorkerLane = 'read' | 'long' | 'semantic' | 'parse';
+
+type TranscriptParserName = 'pi' | 'ohmypi' | 'codex' | 'acp' | 'kimi';
+type TranscriptParser = (sessionFile: string) => Promise<ParseResult>;
+
+const transcriptParsers: Record<TranscriptParserName, TranscriptParser> = {
+  pi: parsePiConversationMessages,
+  ohmypi: parseOhmypiConversationMessages,
+  codex: parseCodexConversationMessages,
+  acp: parseAcpConversationMessages,
+  kimi: parseKimiConversationMessages,
+};
 
 interface PendingJob {
   lane: WorkerLane;
@@ -95,7 +113,7 @@ const COALESCED_OPERATIONS = new Set<DashboardDbOperation>([
   'listSubstrateBugWeights',
 ]);
 
-const workers: Record<WorkerLane, Worker | null> = { read: null, long: null, semantic: null };
+const workers: Record<WorkerLane, Worker | null> = { read: null, long: null, semantic: null, parse: null };
 const pending = new Map<string, PendingJob>();
 const sharedJobs = new Map<string, SharedJob>();
 let latestSemanticJobId: string | null = null;
@@ -146,6 +164,7 @@ function coalescingKey(operation: DashboardDbOperation, payload: unknown): strin
 
 export function workerLane(operation: DashboardDbOperation): WorkerLane {
   if (operation === 'searchSessionsSemantic') return 'semantic';
+  if (operation === 'parseTranscriptSnapshot') return 'parse';
   if (operation === 'costReconcileSweep') return 'long';
   return COALESCED_OPERATIONS.has(operation) ? 'long' : 'read';
 }
@@ -269,6 +288,12 @@ async function executeInline(
       return embedSessions({ ...(payload as EmbedSessionsOptions), autoInstall: true, onProgress });
     case 'getConversationByName':
       return getConversationByName(payload as string);
+    case 'parseTranscriptSnapshot': {
+      const input = payload as { sessionFile: string; parser: string };
+      const parser = transcriptParsers[input.parser as TranscriptParserName];
+      if (!parser) throw new Error(`Unknown transcript parser: ${input.parser}`);
+      return parser(input.sessionFile);
+    }
     case 'getSetting':
       return getSetting(payload as string);
     case 'setSetting': {

--- a/src/dashboard/server/services/dashboard-db-task.ts
+++ b/src/dashboard/server/services/dashboard-db-task.ts
@@ -29,6 +29,7 @@ import { parseCodexConversationMessages } from './codex-conversation-parser.js';
 import { parseKimiConversationMessages } from './kimi-conversation-parser.js';
 import { parseOhmypiConversationMessages } from './ohmypi-conversation-parser.js';
 import { parsePiConversationMessages } from './pi-conversation-parser.js';
+import { parseEntireConversation } from './conversation-service.js';
 import type { ParseResult } from './conversation-service.js';
 
 export type DashboardDbOperation =
@@ -57,7 +58,7 @@ export type DashboardDbOperation =
 type ProgressHandler = (progress: unknown) => void | Promise<void>;
 export type WorkerLane = 'read' | 'long' | 'semantic' | 'parse';
 
-type TranscriptParserName = 'pi' | 'ohmypi' | 'codex' | 'acp' | 'kimi';
+type TranscriptParserName = 'pi' | 'ohmypi' | 'codex' | 'acp' | 'kimi' | 'claude-initial';
 type TranscriptParser = (sessionFile: string) => Promise<ParseResult>;
 
 const transcriptParsers: Record<TranscriptParserName, TranscriptParser> = {
@@ -66,6 +67,7 @@ const transcriptParsers: Record<TranscriptParserName, TranscriptParser> = {
   codex: parseCodexConversationMessages,
   acp: parseAcpConversationMessages,
   kimi: parseKimiConversationMessages,
+  'claude-initial': sessionFile => parseEntireConversation(sessionFile, { flushPendingToolUse: false }),
 };
 
 interface PendingJob {

--- a/src/dashboard/server/services/dashboard-db-worker.ts
+++ b/src/dashboard/server/services/dashboard-db-worker.ts
@@ -28,6 +28,7 @@ import { parseCodexConversationMessages } from './codex-conversation-parser.js';
 import { parseKimiConversationMessages } from './kimi-conversation-parser.js';
 import { parseOhmypiConversationMessages } from './ohmypi-conversation-parser.js';
 import { parsePiConversationMessages } from './pi-conversation-parser.js';
+import { parseEntireConversation } from './conversation-service.js';
 import type { ParseResult } from './conversation-service.js';
 
 type DashboardDbOperation =
@@ -53,7 +54,7 @@ type DashboardDbOperation =
   | 'parseTranscriptSnapshot'
   | 'costReconcileSweep';
 
-type TranscriptParserName = 'pi' | 'ohmypi' | 'codex' | 'acp' | 'kimi';
+type TranscriptParserName = 'pi' | 'ohmypi' | 'codex' | 'acp' | 'kimi' | 'claude-initial';
 type TranscriptParser = (sessionFile: string) => Promise<ParseResult>;
 
 const transcriptParsers: Record<TranscriptParserName, TranscriptParser> = {
@@ -62,6 +63,7 @@ const transcriptParsers: Record<TranscriptParserName, TranscriptParser> = {
   codex: parseCodexConversationMessages,
   acp: parseAcpConversationMessages,
   kimi: parseKimiConversationMessages,
+  'claude-initial': sessionFile => parseEntireConversation(sessionFile, { flushPendingToolUse: false }),
 };
 
 interface DashboardDbRequest {

--- a/src/dashboard/server/services/dashboard-db-worker.ts
+++ b/src/dashboard/server/services/dashboard-db-worker.ts
@@ -176,7 +176,10 @@ async function execute(message: DashboardDbRequest): Promise<void> {
   const startedAt = Date.now();
   try {
     const result = await runJob(message.id, message.operation, message.payload);
-    parentPort?.postMessage({ id: message.id, ok: true, result, startedAt, finishedAt: Date.now() });
+    const bytes = message.operation === 'parseTranscriptSnapshot'
+      ? (result as ParseResult).byteOffset
+      : undefined;
+    parentPort?.postMessage({ id: message.id, ok: true, result, startedAt, finishedAt: Date.now(), bytes });
   } catch (err) {
     parentPort?.postMessage({
       id: message.id,

--- a/src/dashboard/server/services/dashboard-db-worker.ts
+++ b/src/dashboard/server/services/dashboard-db-worker.ts
@@ -23,6 +23,12 @@ import type { EmbedSessionsOptions } from '../../../lib/conversations/embeddings
 import { listSubstrateBugWeights } from '../../../lib/overdeck/substrate-bug-weights-service.js';
 import { collectCodexCostEvents } from '../../../lib/overdeck/cost.js';
 import { collectPiCostEvents } from '../../../lib/costs/reconciler.js';
+import { parseAcpConversationMessages } from './acp-conversation-parser.js';
+import { parseCodexConversationMessages } from './codex-conversation-parser.js';
+import { parseKimiConversationMessages } from './kimi-conversation-parser.js';
+import { parseOhmypiConversationMessages } from './ohmypi-conversation-parser.js';
+import { parsePiConversationMessages } from './pi-conversation-parser.js';
+import type { ParseResult } from './conversation-service.js';
 
 type DashboardDbOperation =
   | 'getDiscoveredStats'
@@ -44,7 +50,19 @@ type DashboardDbOperation =
   | 'getArtifactBySlug'
   | 'listArtifactsForWorkspaceOrIssue'
   | 'unshareArtifactBySlug'
+  | 'parseTranscriptSnapshot'
   | 'costReconcileSweep';
+
+type TranscriptParserName = 'pi' | 'ohmypi' | 'codex' | 'acp' | 'kimi';
+type TranscriptParser = (sessionFile: string) => Promise<ParseResult>;
+
+const transcriptParsers: Record<TranscriptParserName, TranscriptParser> = {
+  pi: parsePiConversationMessages,
+  ohmypi: parseOhmypiConversationMessages,
+  codex: parseCodexConversationMessages,
+  acp: parseAcpConversationMessages,
+  kimi: parseKimiConversationMessages,
+};
 
 interface DashboardDbRequest {
   id: string;
@@ -112,6 +130,12 @@ async function runJob(
       return embedSessions({ ...(payload as EmbedSessionsOptions), autoInstall: true, onProgress: emitProgress });
     case 'getConversationByName':
       return getConversationByName(payload as string);
+    case 'parseTranscriptSnapshot': {
+      const input = payload as { sessionFile: string; parser: string };
+      const parser = transcriptParsers[input.parser as TranscriptParserName];
+      if (!parser) throw new Error(`Unknown transcript parser: ${input.parser}`);
+      return parser(input.sessionFile);
+    }
     case 'getSetting':
       return getSetting(payload as string);
     case 'setSetting': {

--- a/src/dashboard/server/ws-rpc.ts
+++ b/src/dashboard/server/ws-rpc.ts
@@ -15,7 +15,7 @@ import { EventStoreService } from './services/domain-services.js';
 import { ReadModelService, type ReadModelServiceShape } from './read-model.js';
 import { TerminalService } from './services/terminal-service.js';
 import { shouldBroadcastDashboardEvent, streamAgentOutput } from './services/agent-output-stream.js';
-import { getConversationByName } from '../../lib/overdeck/conversations.js';
+import type { LegacyConversation } from '../../lib/overdeck/conversations.js';
 import { contextUsageFromParseResult, gateSnapshotEmission, parseConversationMessages, watchConversation, type ParseState, type ParseResult } from './services/conversation-service.js';
 import { isPiSessionFile } from './services/pi-conversation-parser.js';
 import { resolveAgentHarness, resolvePiSessionPath, resolveCodexRolloutPath, resolveAcpTranscriptPath, resolveKimiWirePath, readLauncherPinnedSessionId } from './routes/jsonl-resolver.js';
@@ -808,7 +808,9 @@ const PanRpcLayer = PanRpcGroup.toLayer(
       [WS_METHODS.subscribeConversationMessages]: (input) =>
         Stream.unwrap(
           Effect.gen(function* () {
-            const conv = getConversationByName(input.conversationName);
+            const conv = yield* Effect.promise(() =>
+              runDashboardDbJob<LegacyConversation | null>('getConversationByName', input.conversationName),
+            );
 
             // PAN-1908: synthetic agent sessions (work/planning/specialist panels)
             // have no conversations-table row. Stream pi/codex work agents by

--- a/src/dashboard/server/ws-rpc.ts
+++ b/src/dashboard/server/ws-rpc.ts
@@ -95,6 +95,12 @@ export function conversationDiscoveringStream(): Stream.Stream<ConversationEvent
   );
 }
 
+/**
+ * Watch and emit full transcript snapshots for harnesses without incremental parsing.
+ * Path resolution, file watching, debounce state, and event emission stay on the main
+ * thread. Callers supply a parser callback that sends CPU-bound parsing through the
+ * dashboard DB worker's parse lane via the job door.
+ */
 export function streamResolvedFullParseSnapshots(
   resolve: () => Promise<string | null>,
   parse: (file: string) => Promise<ParseResult>,

--- a/src/dashboard/server/ws-rpc.ts
+++ b/src/dashboard/server/ws-rpc.ts
@@ -17,11 +17,7 @@ import { TerminalService } from './services/terminal-service.js';
 import { shouldBroadcastDashboardEvent, streamAgentOutput } from './services/agent-output-stream.js';
 import { getConversationByName } from '../../lib/overdeck/conversations.js';
 import { contextUsageFromParseResult, gateSnapshotEmission, parseConversationMessages, parseEntireConversation, watchConversation, type ParseState, type ParseResult } from './services/conversation-service.js';
-import { isPiSessionFile, parsePiConversationMessages } from './services/pi-conversation-parser.js';
-import { isOhmypiSessionFile, parseOhmypiConversationMessages } from './services/ohmypi-conversation-parser.js';
-import { parseCodexConversationMessages } from './services/codex-conversation-parser.js';
-import { parseAcpConversationMessages } from './services/acp-conversation-parser.js';
-import { parseKimiConversationMessages } from './services/kimi-conversation-parser.js';
+import { isPiSessionFile } from './services/pi-conversation-parser.js';
 import { resolveAgentHarness, resolvePiSessionPath, resolveCodexRolloutPath, resolveAcpTranscriptPath, resolveKimiWirePath, readLauncherPinnedSessionId } from './routes/jsonl-resolver.js';
 import { watch as fsWatch } from 'node:fs';
 import { sessionFilePath } from '../../lib/paths.js';
@@ -96,84 +92,6 @@ type AgentIssueRecord = {
 export function conversationDiscoveringStream(): Stream.Stream<ConversationEvent> {
   return Stream.succeed({ kind: 'discovering' } as ConversationEvent).pipe(
     Stream.repeat(Schedule.fixed('2 seconds')),
-  );
-}
-
-/**
- * Live message stream for transcripts that only support a FULL parse (pi, codex)
- * — PAN-1908. Unlike the Claude incremental watcher, pi/codex parsers re-read the
- * whole file, so we emit a full `snapshot: true` event on first subscribe and on
- * every file change (debounced). The client reducer adopts snapshots
- * idempotently and never shrinks a populated view, so re-emitting the full
- * transcript on each append is safe and dedupes by message id.
- *
- * Used for synthetic agent sessions (work/planning/specialist panels) whose pi
- * or codex transcript the operator watches live. fs.watch fires on each append
- * pi/codex makes; a 300ms debounce coalesces bursts during active generation.
- */
-function streamFullParseSnapshots(
-  sessionFile: string,
-  parse: (file: string) => Promise<ParseResult>,
-  model: string | null,
-): Stream.Stream<ConversationEvent, PanRpcError> {
-  return Stream.callback<ConversationEvent, PanRpcError>((queue) =>
-    Effect.acquireRelease(
-      Effect.promise(async () => {
-        let parsing = false;
-        let pendingReparse = false;
-        const emit = async (): Promise<void> => {
-          if (parsing) { pendingReparse = true; return; }
-          parsing = true;
-          try {
-            const result = await parse(sessionFile);
-            try {
-              Queue.offerUnsafe(queue, {
-                kind: 'messages' as const,
-                messages: result.messages,
-                workLog: result.workLog,
-                streaming: result.streaming,
-                snapshot: true,
-                proposedPlan: result.proposedPlan,
-                compactBoundaries:
-                  result.compactBoundaries && result.compactBoundaries.length > 0
-                    ? result.compactBoundaries
-                    : undefined,
-                contextUsage: contextUsageFromParseResult(result, model),
-              });
-            } catch {
-              // Queue shut down (client disconnected) — ignore.
-            }
-          } catch {
-            // Transient parse failure (read during a write) — the next change
-            // event re-parses cleanly.
-          } finally {
-            parsing = false;
-            if (pendingReparse) { pendingReparse = false; void emit(); }
-          }
-        };
-
-        await emit(); // authoritative initial snapshot
-
-        let debounce: ReturnType<typeof setTimeout> | null = null;
-        let watcher: ReturnType<typeof fsWatch> | null = null;
-        try {
-          watcher = fsWatch(sessionFile, () => {
-            if (debounce) return;
-            debounce = setTimeout(() => { debounce = null; void emit(); }, 300);
-          });
-        } catch {
-          // If the watcher can't attach, the initial snapshot still rendered;
-          // the client's HTTP path is its own fallback on reconnect.
-        }
-        return {
-          stop: () => {
-            if (debounce) { clearTimeout(debounce); debounce = null; }
-            if (watcher) { try { watcher.close(); } catch { /* ignore */ } }
-          },
-        };
-      }),
-      (handle) => Effect.sync(() => handle.stop()),
-    ),
   );
 }
 
@@ -334,15 +252,6 @@ export function streamResolvedFullParseSnapshots(
 
 type FullParseSnapshotStream = Stream.Stream<ConversationEvent, PanRpcError>;
 
-function ohmypiSnapshotParser(harness: unknown): (file: string) => Promise<ParseResult> {
-  switch (harness) {
-    case 'pi':
-      return parsePiConversationMessages;
-    default:
-      return parseOhmypiConversationMessages;
-  }
-}
-
 export function streamHarnessFullParseSnapshots(
   sessionName: string,
   harness: unknown,
@@ -358,10 +267,22 @@ export function streamHarnessFullParseSnapshots(
 
   // A missing kind gets the caller's discovering stream (the kimi-code hang); `workspace` is the conversation cwd, which the kimi resolver needs because conversations have no AgentState row to derive it from.
   switch (behavior.transcriptKind) {
-    case 'ohmypi-jsonl': return streamResolved(() => resolvePiSessionPath(sessionName), ohmypiSnapshotParser(harness));
-    case 'codex-rollout-jsonl': return streamResolved(() => resolveCodexRolloutPath(sessionName), parseCodexConversationMessages);
-    case 'acp-jsonl': return streamResolved(() => resolveAcpTranscriptPath(sessionName), parseAcpConversationMessages);
-    case 'kimi-wire-jsonl': return streamResolved(() => resolveKimiWirePath(sessionName, workspace ? { workspaceOverride: workspace } : {}), parseKimiConversationMessages);
+    case 'ohmypi-jsonl': return streamResolved(
+      () => resolvePiSessionPath(sessionName),
+      file => runDashboardDbJob('parseTranscriptSnapshot', { sessionFile: file, parser: harness === 'pi' ? 'pi' : 'ohmypi' }),
+    );
+    case 'codex-rollout-jsonl': return streamResolved(
+      () => resolveCodexRolloutPath(sessionName),
+      file => runDashboardDbJob('parseTranscriptSnapshot', { sessionFile: file, parser: 'codex' }),
+    );
+    case 'acp-jsonl': return streamResolved(
+      () => resolveAcpTranscriptPath(sessionName),
+      file => runDashboardDbJob('parseTranscriptSnapshot', { sessionFile: file, parser: 'acp' }),
+    );
+    case 'kimi-wire-jsonl': return streamResolved(
+      () => resolveKimiWirePath(sessionName, workspace ? { workspaceOverride: workspace } : {}),
+      file => runDashboardDbJob('parseTranscriptSnapshot', { sessionFile: file, parser: 'kimi' }),
+    );
     default: return null;
   }
 }

--- a/src/dashboard/server/ws-rpc.ts
+++ b/src/dashboard/server/ws-rpc.ts
@@ -16,7 +16,7 @@ import { ReadModelService, type ReadModelServiceShape } from './read-model.js';
 import { TerminalService } from './services/terminal-service.js';
 import { shouldBroadcastDashboardEvent, streamAgentOutput } from './services/agent-output-stream.js';
 import { getConversationByName } from '../../lib/overdeck/conversations.js';
-import { contextUsageFromParseResult, gateSnapshotEmission, parseConversationMessages, parseEntireConversation, watchConversation, type ParseState, type ParseResult } from './services/conversation-service.js';
+import { contextUsageFromParseResult, gateSnapshotEmission, parseConversationMessages, watchConversation, type ParseState, type ParseResult } from './services/conversation-service.js';
 import { isPiSessionFile } from './services/pi-conversation-parser.js';
 import { resolveAgentHarness, resolvePiSessionPath, resolveCodexRolloutPath, resolveAcpTranscriptPath, resolveKimiWirePath, readLauncherPinnedSessionId } from './routes/jsonl-resolver.js';
 import { watch as fsWatch } from 'node:fs';
@@ -871,7 +871,10 @@ const PanRpcLayer = PanRpcGroup.toLayer(
                   // Parse the complete existing transcript before subscribing to
                   // appends. Keep pending tool_use entries in parser state for the
                   // watcher instead of flushing them into the display-only work log.
-                  const initial = await parseEntireConversation(sessionFile, { flushPendingToolUse: false });
+                  const initial = await runDashboardDbJob<ParseResult>('parseTranscriptSnapshot', {
+                    sessionFile,
+                    parser: 'claude-initial',
+                  });
                   let currentByteOffset = initial.byteOffset;
                   let currentContextUsage = contextUsageFromParseResult(initial, model);
                   // Per-subscription high-water mark of the largest full transcript

--- a/tests/unit/dashboard/claude-initial-parse-job.test.ts
+++ b/tests/unit/dashboard/claude-initial-parse-job.test.ts
@@ -1,0 +1,64 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { runDashboardDbJob } from '../../../src/dashboard/server/services/dashboard-db-task.js';
+import { parseEntireConversation, type ParseResult } from '../../../src/dashboard/server/services/conversation-service.js';
+
+const claudeFixture = new URL(
+  '../../../src/dashboard/server/services/__fixtures__/misordered-session.jsonl',
+  import.meta.url,
+);
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('Claude initial transcript parse job', () => {
+  it('matches the direct parser and preserves its byte offset', async () => {
+    const expected = await parseEntireConversation(claudeFixture.pathname, { flushPendingToolUse: false });
+    const actual = await runDashboardDbJob<ParseResult>('parseTranscriptSnapshot', {
+      sessionFile: claudeFixture.pathname,
+      parser: 'claude-initial',
+    });
+
+    expect(actual.messages).toEqual(expected.messages);
+    expect(actual.byteOffset).toBe(expected.byteOffset);
+  });
+
+  it('preserves parser state collections across a worker-compatible clone', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'claude-initial-parse-'));
+    tempDirs.push(dir);
+    const sessionFile = join(dir, 'session.jsonl');
+    writeFileSync(sessionFile, `${JSON.stringify({
+      type: 'assistant',
+      uuid: 'assistant-with-orphan-edit',
+      timestamp: '2026-08-16T00:00:00.000Z',
+      message: {
+        id: 'message-with-orphan-edit',
+        role: 'assistant',
+        content: [{
+          type: 'tool_use',
+          id: 'orphan-edit',
+          name: 'Edit',
+          input: { file_path: '/tmp/example.ts', old_string: 'a', new_string: 'b' },
+        }],
+        stop_reason: 'tool_use',
+      },
+    })}\n`);
+    const result = await runDashboardDbJob<ParseResult>('parseTranscriptSnapshot', {
+      sessionFile,
+      parser: 'claude-initial',
+    });
+    const cloned = structuredClone(result);
+
+    expect(cloned.pendingToolUse).toBeInstanceOf(Map);
+    expect(cloned.unresolvedResults).toBeInstanceOf(Map);
+    expect(cloned.countedUsageIds).toBeInstanceOf(Set);
+    expect(cloned.planToolUseIds).toBeInstanceOf(Set);
+    expect(cloned.orphanToolUseIds).toBeInstanceOf(Set);
+    expect(cloned.fileEditsByAssistantId).toBeInstanceOf(Map);
+  });
+});

--- a/tests/unit/dashboard/db-task-instrumentation.test.ts
+++ b/tests/unit/dashboard/db-task-instrumentation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../../src/lib/overdeck/cost.js', () => ({
   collectCodexCostEvents: vi.fn(async () => ({ events: [], verdicts: [], stats: { scanned: 0, cacheSkipped: 0 } })),
@@ -9,6 +9,15 @@ import {
   formatSlowJobLine,
   runDashboardDbJob,
 } from '../../../src/dashboard/server/services/dashboard-db-task.js';
+
+const piFixture = new URL(
+  '../../../src/dashboard/server/services/__tests__/pi-conversation-parser.fixture.jsonl',
+  import.meta.url,
+);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe('dashboard database job instrumentation', () => {
   it('formats queue wait from enqueue and start stamps', () => {
@@ -28,6 +37,12 @@ describe('dashboard database job instrumentation', () => {
     })).toBe('[db-jobs] slow: op=costReconcileSweep lane=long waitMs=20 runMs=1001 depth=0');
   });
 
+  it('includes parsed bytes only for transcript parse slow lines', () => {
+    expect(formatSlowJobLine({
+      op: 'parseTranscriptSnapshot', lane: 'parse', waitMs: 0, runMs: 1_001, depth: 0, bytes: 25_000_000,
+    })).toBe('[db-jobs] slow: op=parseTranscriptSnapshot lane=parse waitMs=0 runMs=1001 depth=0 bytes=25000000');
+  });
+
   it('returns null when wait and run time are at the threshold', () => {
     expect(formatSlowJobLine({
       op: 'getDiscoveredStats', lane: 'read', waitMs: 1_000, runMs: 1_000, depth: 0,
@@ -42,6 +57,21 @@ describe('dashboard database job instrumentation', () => {
 
     expect(warnSpy).toHaveBeenCalledWith(
       '[db-jobs] slow: op=costReconcileSweep lane=long waitMs=0 runMs=1001 depth=0',
+    );
+  });
+
+  it('logs parsed bytes for a slow inline transcript parse', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    let nowCalls = 0;
+    vi.spyOn(Date, 'now').mockImplementation(() => ++nowCalls === 1 ? 1_000 : 2_001);
+
+    const result = await runDashboardDbJob<{ byteOffset: number }>('parseTranscriptSnapshot', {
+      sessionFile: piFixture.pathname,
+      parser: 'pi',
+    });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      `[db-jobs] slow: op=parseTranscriptSnapshot lane=parse waitMs=0 runMs=1001 depth=0 bytes=${result.byteOffset}`,
     );
   });
 });

--- a/tests/unit/dashboard/db-task-lanes.test.ts
+++ b/tests/unit/dashboard/db-task-lanes.test.ts
@@ -2,8 +2,15 @@ import { describe, expect, it } from 'vitest';
 
 import {
   type DashboardDbOperation,
+  runDashboardDbJob,
   workerLane,
 } from '../../../src/dashboard/server/services/dashboard-db-task.js';
+import { parsePiConversationMessages } from '../../../src/dashboard/server/services/pi-conversation-parser.js';
+
+const piFixture = new URL(
+  '../../../src/dashboard/server/services/__tests__/pi-conversation-parser.fixture.jsonl',
+  import.meta.url,
+);
 
 describe('dashboard database worker lanes', () => {
   it.each([
@@ -27,5 +34,25 @@ describe('dashboard database worker lanes', () => {
 
   it('routes semantic search to its dedicated lane', () => {
     expect(workerLane('searchSessionsSemantic')).toBe('semantic');
+  });
+
+  it('routes transcript parsing to its dedicated lane', () => {
+    expect(workerLane('parseTranscriptSnapshot')).toBe('parse');
+  });
+
+  it('dispatches transcript parsing through the job surface', async () => {
+    const expected = await parsePiConversationMessages(piFixture.pathname);
+
+    await expect(runDashboardDbJob('parseTranscriptSnapshot', {
+      sessionFile: piFixture.pathname,
+      parser: 'pi',
+    })).resolves.toEqual(expected);
+  });
+
+  it('rejects unknown transcript parsers', async () => {
+    await expect(runDashboardDbJob('parseTranscriptSnapshot', {
+      sessionFile: piFixture.pathname,
+      parser: 'unknown',
+    })).rejects.toThrow('Unknown transcript parser: unknown');
   });
 });

--- a/tests/unit/dashboard/db-task-lanes.test.ts
+++ b/tests/unit/dashboard/db-task-lanes.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../../src/dashboard/server/services/pi-conversation-parser.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/dashboard/server/services/pi-conversation-parser.js')>();
+  return {
+    ...actual,
+    parsePiConversationMessages: vi.fn(actual.parsePiConversationMessages),
+  };
+});
 
 import {
   type DashboardDbOperation,
@@ -54,5 +62,18 @@ describe('dashboard database worker lanes', () => {
       sessionFile: piFixture.pathname,
       parser: 'unknown',
     })).rejects.toThrow('Unknown transcript parser: unknown');
+  });
+
+  it('coalesces concurrent parses with identical payloads', async () => {
+    vi.mocked(parsePiConversationMessages).mockClear();
+    const payload = { sessionFile: piFixture.pathname, parser: 'pi' };
+
+    const [first, second] = await Promise.all([
+      runDashboardDbJob('parseTranscriptSnapshot', payload),
+      runDashboardDbJob('parseTranscriptSnapshot', payload),
+    ]);
+
+    expect(parsePiConversationMessages).toHaveBeenCalledOnce();
+    expect(first).toEqual(second);
   });
 });

--- a/tests/unit/dashboard/transcript-parse-worker.test.ts
+++ b/tests/unit/dashboard/transcript-parse-worker.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -26,27 +26,42 @@ const tempDirs: string[] = [];
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.doUnmock('../../../src/dashboard/server/services/dashboard-db-task.js');
+  vi.doUnmock('../../../src/dashboard/server/routes/jsonl-resolver.js');
+  vi.resetModules();
   for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
 
 describe('transcript parse worker routing', () => {
-  it('keeps every full transcript parser behind the parse job door in ws-rpc', () => {
-    const source = readFileSync(new URL('../../../src/dashboard/server/ws-rpc.ts', import.meta.url), 'utf8');
+  it('dispatches every full-snapshot harness stream through the parse job door', async () => {
+    vi.resetModules();
+    const jobSpy = vi.fn<(operation: string, payload: unknown) => Promise<ParseResult>>(
+      async () => parsePiConversationMessages(piFixture.pathname),
+    );
+    vi.doMock('../../../src/dashboard/server/services/dashboard-db-task.js', () => ({
+      runDashboardDbJob: jobSpy,
+    }));
+    vi.doMock('../../../src/dashboard/server/routes/jsonl-resolver.js', () => ({
+      resolveAgentHarness: vi.fn(async () => 'claude-code'),
+      resolvePiSessionPath: vi.fn(async () => piFixture.pathname),
+      resolveCodexRolloutPath: vi.fn(async () => piFixture.pathname),
+      resolveAcpTranscriptPath: vi.fn(async () => piFixture.pathname),
+      resolveKimiWirePath: vi.fn(async () => piFixture.pathname),
+      readLauncherPinnedSessionId: vi.fn(async () => null),
+    }));
+    const { streamHarnessFullParseSnapshots: isolatedStreamHarness } = await import(
+      '../../../src/dashboard/server/ws-rpc.js'
+    );
 
-    for (const directParser of [
-      'parsePiConversationMessages',
-      'parseOhmypiConversationMessages',
-      'parseCodexConversationMessages',
-      'parseAcpConversationMessages',
-      'parseKimiConversationMessages',
-      'parseEntireConversation',
-    ]) {
-      expect(source).not.toContain(directParser);
+    for (const harness of ['pi', 'ohmypi', 'codex', 'acp', 'kimi-code']) {
+      const stream = isolatedStreamHarness(`session-${harness}`, harness, null);
+      await Effect.runPromise(stream!.pipe(Stream.take(1), Stream.runCollect));
     }
-    expect(source).toContain("parser: harness === 'pi' ? 'pi' : 'ohmypi'");
-    for (const parser of ['codex', 'acp', 'kimi', 'claude-initial']) {
-      expect(source).toContain(`parser: '${parser}'`);
-    }
+
+    expect(jobSpy.mock.calls.map(([, payload]) => (payload as { parser: string }).parser)).toEqual([
+      'pi', 'ohmypi', 'codex', 'acp', 'kimi',
+    ]);
+    expect(jobSpy.mock.calls.every(([operation]) => operation === 'parseTranscriptSnapshot')).toBe(true);
   });
 
   it.each([

--- a/tests/unit/dashboard/transcript-parse-worker.test.ts
+++ b/tests/unit/dashboard/transcript-parse-worker.test.ts
@@ -1,0 +1,106 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Effect, Stream } from 'effect';
+
+import { runDashboardDbJob } from '../../../src/dashboard/server/services/dashboard-db-task.js';
+import { parseEntireConversation, type ParseResult } from '../../../src/dashboard/server/services/conversation-service.js';
+import { parseCodexConversationMessages } from '../../../src/dashboard/server/services/codex-conversation-parser.js';
+import { parsePiConversationMessages } from '../../../src/dashboard/server/services/pi-conversation-parser.js';
+import { streamResolvedFullParseSnapshots } from '../../../src/dashboard/server/ws-rpc.js';
+
+const claudeFixture = new URL(
+  '../../../src/dashboard/server/services/__fixtures__/misordered-session.jsonl',
+  import.meta.url,
+);
+const piFixture = new URL(
+  '../../../src/dashboard/server/services/__tests__/pi-conversation-parser.fixture.jsonl',
+  import.meta.url,
+);
+const codexFixture = new URL(
+  '../../../src/lib/cost-parsers/__tests__/fixtures/codex/rollout.jsonl',
+  import.meta.url,
+);
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.useRealTimers();
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('transcript parse worker routing', () => {
+  it('keeps every full transcript parser behind the parse job door in ws-rpc', () => {
+    const source = readFileSync(new URL('../../../src/dashboard/server/ws-rpc.ts', import.meta.url), 'utf8');
+
+    for (const directParser of [
+      'parsePiConversationMessages',
+      'parseOhmypiConversationMessages',
+      'parseCodexConversationMessages',
+      'parseAcpConversationMessages',
+      'parseKimiConversationMessages',
+      'parseEntireConversation',
+    ]) {
+      expect(source).not.toContain(directParser);
+    }
+    expect(source).toContain("parser: harness === 'pi' ? 'pi' : 'ohmypi'");
+    for (const parser of ['codex', 'acp', 'kimi', 'claude-initial']) {
+      expect(source).toContain(`parser: '${parser}'`);
+    }
+  });
+
+  it.each([
+    ['claude-initial', claudeFixture, (file: string) => parseEntireConversation(file, { flushPendingToolUse: false })],
+    ['pi', piFixture, parsePiConversationMessages],
+    ['codex', codexFixture, parseCodexConversationMessages],
+  ] as const)('matches the direct %s parser', async (parser, fixture, directParse) => {
+    const expected = await directParse(fixture.pathname);
+    const actual = await runDashboardDbJob<ParseResult>('parseTranscriptSnapshot', {
+      sessionFile: fixture.pathname,
+      parser,
+    });
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('parses a generated transcript larger than 20 MB without losing its message', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'large-transcript-'));
+    tempDirs.push(dir);
+    const sessionFile = join(dir, 'session.jsonl');
+    const text = 'x'.repeat(20 * 1024 * 1024);
+    writeFileSync(sessionFile, `${JSON.stringify({
+      type: 'message',
+      id: 'large-message',
+      timestamp: '2026-08-16T00:00:00.000Z',
+      message: { role: 'user', content: [{ type: 'text', text }] },
+    })}\n`);
+    expect(statSync(sessionFile).size).toBeGreaterThanOrEqual(20 * 1024 * 1024);
+
+    const result = await runDashboardDbJob<ParseResult>('parseTranscriptSnapshot', {
+      sessionFile,
+      parser: 'pi',
+    });
+
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]?.text).toHaveLength(text.length);
+  });
+
+  it('preserves the full snapshot wire shape when parsing through the job door', async () => {
+    const direct = await Effect.runPromise(
+      streamResolvedFullParseSnapshots(
+        async () => piFixture.pathname,
+        parsePiConversationMessages,
+        null,
+      ).pipe(Stream.take(1), Stream.runCollect),
+    );
+    const jobBacked = await Effect.runPromise(
+      streamResolvedFullParseSnapshots(
+        async () => piFixture.pathname,
+        file => runDashboardDbJob('parseTranscriptSnapshot', { sessionFile: file, parser: 'pi' }),
+        null,
+      ).pipe(Stream.take(1), Stream.runCollect),
+    );
+
+    expect(Array.from(jobBacked)).toEqual(Array.from(direct));
+  });
+});


### PR DESCRIPTION
**Issue:** #3752

## Acceptance Criteria

- [ ] Add parseTranscriptSnapshot op and dedicated 'parse' worker lane
- [ ] Rewire harness snapshot streams to dispatch parsing through the job door
- [ ] Route the Claude incremental watcher's initial full parse through the job door
- [ ] Resolve the conversation row through the existing getConversationByName job op
- [ ] Coalesce concurrent same-file parse jobs through sharedJobs
- [ ] Add bytes= to the parse slow-line and lock the no-main-thread-parse routing in a new test suite
- [ ] Document the parse lane and worker-venue transcript flow