### PR TITLE
PAN-3753

### DIFF
--- a/docs/FLYWHEEL.md
+++ b/docs/FLYWHEEL.md
@@ -215,6 +215,11 @@ project's effective merge-train flag is on; the ready set comes from that
 project's review-status records, so **no flywheel run is required**
 ([PAN-1696](https://github.com/eltmon/overdeck/issues/1696)).
 
+The merge train is actionable only for merge-eligible issues: its rows render only when
+canonical pipeline membership is `in_flight`. The merge-next endpoint revalidates the
+selected head server-side immediately before shipping. If membership changed or needs
+disposition, it returns HTTP `409` with the disposition reason and merges nothing.
+
 ### Orchestrator scope vs merge-train independence
 
 Two things are easy to conflate, so state them separately:

--- a/docs/MERGE-WORKFLOW.md
+++ b/docs/MERGE-WORKFLOW.md
@@ -141,6 +141,23 @@ repository's forge adapter to merge its PR or MR, waits for positive forge
 evidence, then runs `postMergeLifecycle()` to clean up labels, Docker networks,
 and agent sessions.
 
+## Review-status retirement and terminal generations
+
+Review status keeps its historical verdicts after the row stops being actionable. The
+`retiredAt` timestamp is set when a closed pull request is observed during refresh, when
+the pull-request webhook reports closure, or when lazy review-status loading discovers
+the closed artifact. Consumers exclude retired rows from patrols, merge projections, and
+status stamping instead of deleting their history.
+
+A fresh pull request clears `retiredAt`. Starting fresh work also clears it, so a new
+review cycle can use the same issue record without inheriting the retired state.
+
+UAT generation history is terminal. Backfill marks a generation promoted only when each
+member branch is contained in `main` by the shared positive ancestor check; it does not
+reopen or rebuild that generation. Generation names use the date and codename, followed
+by `-2`, `-3`, and later suffixes when more than one generation is created on the same
+day.
+
 ## After another feature merges
 
 A merge does not trigger a background scan of sibling branches. An open feature
@@ -329,4 +346,3 @@ The destructive/non-reversible completion steps are owned by close-out, not merg
 `pan close <id>` / dashboard Close Out completes the xBRIEF, archives planning artifacts,
 optionally tears down the workspace or deletes feature branches according to `close_out`
 config, closes the tracker issue, and clears review status.
-

--- a/docs/PIPELINE-MEMBERSHIP.md
+++ b/docs/PIPELINE-MEMBERSHIP.md
@@ -52,6 +52,13 @@ All consumers use one of these representations of the same verdict:
 - Dashboard API: `GET /api/pipeline/membership?project=<project-key>`, backed by the cached membership service. `POST /api/pipeline/membership/refresh?project=<project-key>` is the operator-initiated retry: it forces a re-gather via `refreshMembershipSnapshotsForProjects()` (PAN-2972) and returns the fresh snapshot, because re-reading a cold snapshot can never heal it.
 - Issue DTO: total `pipelineMembership` with `available`, `inPipeline`, `bucket`, and `labelDrift`, used by the dashboard frontend. `available: false` means durable membership could not be resolved; a successful lookup with no candidate is explicitly `clean_terminal`.
 
+The merge-eligibility consumers use this same read door. The Deacon's
+`readyForMerge` blocker, stuck-ready patrol, and startup sweep require `in_flight`
+membership before acting. `listEligibleCandidatesByProject()` applies the same gate to
+the merge-train projection, and the merge-next endpoint gathers membership again before
+shipping the selected head. A row in any other bucket remains visible for disposition
+but cannot enter a merge action.
+
 Dashboard GET requests are snapshot-only; they never gather tracker or git evidence inside the request. A successful GET or POST refresh returns HTTP `200` with the bare `PipelineMembership[]` array. A completed gather that could not determine membership also returns HTTP `200`, but with `{ status: 'unavailable', reason, message, projectKey }`. The typed reason is one of `missing_issue_prefix`, `repo_unavailable`, `default_branch_unresolved`, `forge_unavailable`, `tracker_unconfigured`, or `gather_failed`, so callers can distinguish an empty pipeline from a blind spot. When multiple reasons apply to the same project, the checks run in precedence order: tracker type is resolved first (a project with no tracker reports `tracker_unconfigured`), then the issue prefix is checked (a project with a tracker but no prefix reports `missing_issue_prefix`). HTTP `503` is reserved for the transient cold-boot state while the first background refresh is still loading.
 
 The frontend Retry button POSTs to the refresh route rather than refetching the GET. Loading and determined failures leave the issue tree and its actions mounted, with a status message or explicit Retry alongside them. Lifecycle events invalidate the affected query, so there is no interval membership poll.

--- a/drizzle/overdeck/0000_overdeck_init.sql
+++ b/drizzle/overdeck/0000_overdeck_init.sql
@@ -355,6 +355,7 @@ CREATE TABLE `review_status` (
 	`strike_next_attempt_at` integer,
 	`strike_landing_attempts` text,
 	`review_cycle_history` text,
+	`retired_at` integer,
 	`conflicts_since` text
 );
 --> statement-breakpoint

--- a/src/cli/commands/flywheel.ts
+++ b/src/cli/commands/flywheel.ts
@@ -427,7 +427,7 @@ export function formatFlywheelStatus(status: FlywheelStatus): string {
 }
 
 async function formatMergeQueueForCli(cwd: string, json?: boolean): Promise<string> {
-  const q = await Effect.runPromise(computeMergeQueueFromCandidates(listEligibleCandidatesByProject(cwd), cwd).pipe(Effect.provide(nodeServicesLayer)));
+  const q = await Effect.runPromise(computeMergeQueueFromCandidates(await listEligibleCandidatesByProject(cwd), cwd).pipe(Effect.provide(nodeServicesLayer)));
   return json ? JSON.stringify({ mergeQueue: q }, null, 2) : `Merge queue:\n${q.map(i => `  ${i.pr ? `#${i.pr}` : 'no-pr'} ${i.issueId} ${i.title}`).join('\n') || '  (empty)'}`;
 }
 
@@ -817,7 +817,7 @@ export async function flywheelStopCommand(options: Pick<ReportOptions, 'cwd'> = 
 
 async function buildFlywheelStateReport(status: FlywheelStatus, cwd: string): Promise<string> {
   // PAN-1696: Compute the merge queue from the pipeline ready set, not flywheel activePipeline.
-  const candidates = listEligibleCandidatesByProject(cwd);
+  const candidates = await listEligibleCandidatesByProject(cwd);
   const mergeQueue = await Effect.runPromise(computeMergeQueueFromCandidates(candidates, cwd).pipe(Effect.provide(nodeServicesLayer)));
   return formatFlywheelStateReport(status, mergeQueue);
 }

--- a/src/dashboard/server/main.ts
+++ b/src/dashboard/server/main.ts
@@ -744,7 +744,7 @@ setTimeout(() => {
     });
 }, 1000);
 // Restore readyForMerge for issues where review+test passed but readyForMerge is stuck false.
-fixStuckReadyForMerge();
+await fixStuckReadyForMerge();
 // PAN-869: restore reviewStatus='passed' for issues with COMMENTED reviews that were incorrectly marked 'failed'
 fixStuckCommentedReviews();
 // PAN-1771: re-derive GitHub-native blockers from live PR state. Webhooks missed

--- a/src/dashboard/server/routes/__tests__/merge-train.test.ts
+++ b/src/dashboard/server/routes/__tests__/merge-train.test.ts
@@ -70,6 +70,18 @@ const mergeBatchMocks = vi.hoisted(() => ({
   ),
 }));
 
+const mergeEligibilityMocks = vi.hoisted(() => ({
+  gatherMergeEligibility: vi.fn(async (issueIds: string[]) => new Map(issueIds.map((issueId) => [issueId, {
+    issueId, bucket: 'in_flight', inPipeline: true, reasons: ['open PR'], labelDrift: null,
+    lenses: { L1_openPr: true, L2_unmergedBranch: false, L3_issueOpen: true, L4_phaseLabel: null },
+  }]))),
+}));
+
+vi.mock('../../../../lib/cloister/merge-eligibility.js', () => ({
+  gatherMergeEligibility: mergeEligibilityMocks.gatherMergeEligibility,
+  isMergeEligible: (membership: { bucket: string }) => membership.bucket === 'in_flight',
+}));
+
 /**
  * The real batch semantics, used by the ported PAN-1691 case: merge one at a
  * time and stop at the first failure, because everything after it would need
@@ -471,6 +483,22 @@ describe('PAN-1696 merge-train-routes', () => {
 
   // ── AC3: merge-next from a named project's ready set ───────────────────────
   describe('POST /api/merge-train/merge-next (ac3)', () => {
+    it('returns 409 without merging when the queue head needs disposition', async () => {
+      const gatherEligibility = vi.fn(async () => new Map([['MIN-831', {
+        issueId: 'MIN-831', bucket: 'planned_backlog' as const, inPipeline: true,
+        reasons: ['open issue with an unmerged branch but no PR — needs disposition'], labelDrift: null,
+        lenses: { L1_openPr: false, L2_unmergedBranch: true, L3_issueOpen: true, L4_phaseLabel: 'planned' },
+      }]]));
+
+      const result = await postMergeTrainMergeNextPayload(
+        { n: 1, project: 'myn' },
+        { getOrderedIssueIds: async () => ['MIN-831'], gatherEligibility },
+      );
+
+      expect(result).toEqual({ status: 409, body: { error: expect.stringContaining('MIN-831 is not merge-eligible:') } });
+      expect(mergeBatchMocks.shipMergeBatch).not.toHaveBeenCalled();
+    });
+
     it('merges the first n issues of the named project ready set', async () => {
       mergeOrderMocks.listEligibleCandidatesByProject.mockImplementation((path: string) =>
         path === '/repos/myn'

--- a/src/dashboard/server/routes/merge-train.ts
+++ b/src/dashboard/server/routes/merge-train.ts
@@ -25,6 +25,8 @@ import {
   listEligibleCandidatesByProject,
   type MergeQueueItem,
 } from '../../../lib/flywheel-merge-order.js';
+import { gatherMergeEligibility, isMergeEligible } from '../../../lib/cloister/merge-eligibility.js';
+import type { PipelineMembership } from '../../../lib/pipeline-membership.js';
 
 const readUnknownJsonBody = Effect.gen(function* () {
   const request = yield* HttpServerRequest.HttpServerRequest;
@@ -128,6 +130,7 @@ export async function getMergeTrainGenerationsPayload(): Promise<MergeTrainGener
 export interface MergeTrainMergeNextDeps {
   getOrderedIssueIds?: (projectPath: string) => Promise<string[]>;
   merge?: (issueId: string) => Promise<{ ok: true } | { ok: false; reason: string }>;
+  gatherEligibility?: (issueIds: string[]) => Promise<Map<string, PipelineMembership>>;
 }
 
 async function defaultOrderedIssueIdsForProject(projectPath: string): Promise<string[]> {
@@ -170,6 +173,14 @@ export async function postMergeTrainMergeNextPayload(
 
   const ordered = await (deps.getOrderedIssueIds ?? defaultOrderedIssueIdsForProject)(resolve(config.path));
   const issueIds = ordered.slice(0, n);
+  const memberships = await (deps.gatherEligibility ?? gatherMergeEligibility)(issueIds);
+  for (const issueId of issueIds) {
+    const membership = memberships.get(issueId.toUpperCase());
+    if (!membership || !isMergeEligible(membership)) {
+      const reason = membership?.reasons.join('; ') || 'pipeline membership unavailable';
+      return { status: 409, body: { error: `${issueId} is not merge-eligible: ${reason}` } };
+    }
+  }
   const { shipMergeBatch } = await import('../../../lib/cloister/merge-batch.js');
   const outcomes = await shipMergeBatch(issueIds, { merge: deps.merge ?? defaultMergeOne });
   return { status: 200, body: { projectKey, outcomes } };

--- a/src/dashboard/server/routes/merge-train.ts
+++ b/src/dashboard/server/routes/merge-train.ts
@@ -72,7 +72,7 @@ async function queueEntryForProject(
   if (!enabled) return { ...base, queue: [] };
 
   const projectPath = resolve(config.path);
-  const candidates = listEligibleCandidatesByProject(projectPath);
+  const candidates = await listEligibleCandidatesByProject(projectPath);
   if (candidates.length === 0) return { ...base, queue: [] };
 
   const queue = await Effect.runPromise(
@@ -131,7 +131,7 @@ export interface MergeTrainMergeNextDeps {
 }
 
 async function defaultOrderedIssueIdsForProject(projectPath: string): Promise<string[]> {
-  const candidates = listEligibleCandidatesByProject(projectPath);
+  const candidates = await listEligibleCandidatesByProject(projectPath);
   if (candidates.length === 0) return [];
   const queue = await Effect.runPromise(
     computeMergeQueueFromCandidates(candidates, projectPath).pipe(Effect.provide(nodeServicesLayer)),

--- a/src/dashboard/server/services/__tests__/uat-train.test.ts
+++ b/src/dashboard/server/services/__tests__/uat-train.test.ts
@@ -576,6 +576,26 @@ describe('runUatTrainReconcile — polyrepo routing', () => {
     expect(deps.getFeatureAnchor).toBeTypeOf('function');
   });
 
+  it('checks containment for read-only generation repositories', async () => {
+    mocks.findProjectByPathSync.mockReturnValue({
+      name: 'myn', path: POLY_ROOT, workspace: { type: 'polyrepo' },
+    });
+    const isBranchContainedInMain = vi.fn().mockResolvedValue(true);
+    mocks.buildPolyrepoGitDeps.mockReturnValue(new Map([
+      ['docs', { isBranchContainedInMain }],
+    ]));
+
+    await runUatTrainReconcile({ projectRoot: POLY_ROOT });
+    const contained = await capturedDeps().isGenerationContainedInMain!({
+      name: 'uat/min-otter-0727',
+      repos: [{ repoKey: 'docs', branch: 'feature/min-901' }],
+    } as UatGeneration);
+
+    expect(mocks.buildPolyrepoGitDeps).toHaveBeenCalledWith(expect.any(Array), { includeReadOnly: true });
+    expect(isBranchContainedInMain).toHaveBeenCalledWith('feature/min-901');
+    expect(contained).toBe(true);
+  });
+
   it('invokes polyrepo assembly, not the monorepo engine, for a polyrepo project', async () => {
     mocks.findProjectByPathSync.mockReturnValue({
       name: 'myn', path: POLY_ROOT, workspace: { type: 'polyrepo' },

--- a/src/dashboard/server/services/review-status-reconcile-service.ts
+++ b/src/dashboard/server/services/review-status-reconcile-service.ts
@@ -10,6 +10,8 @@ import {
 const POLL_INTERVAL_MS = 60_000;
 
 let reconcileTimer: ReturnType<typeof setInterval> | null = null;
+const lastHealedUpdatedAt = new Map<string, string>();
+const warnedNonConverging = new Set<string>();
 
 interface ReviewStatusEventPayload {
   issueId: string;
@@ -34,7 +36,7 @@ async function reconcileOnce(): Promise<void> {
   // not duplicate an event that the read door just healed.
   for (const issueId of Object.keys(cached)) {
     const canonical = getReviewStatusSync(issueId);
-    if (!canonical) continue;
+    if (!canonical || canonical.retiredAt) continue;
     canonicalByIssue.set(issueId.toUpperCase(), canonical);
   }
 
@@ -56,6 +58,15 @@ async function reconcileOnce(): Promise<void> {
       sameCanonicalReviewStatus(latestPayload.status, canonical)
     ) continue;
 
+    if (lastHealedUpdatedAt.get(issueId) === canonical.updatedAt) {
+      const warningKey = `${issueId}:${canonical.updatedAt}`;
+      if (!warnedNonConverging.has(warningKey)) {
+        console.warn(`[review-status-reconcile] NOT CONVERGING for ${issueId}: canonical=${canonical.updatedAt} event=${lastUpdatedAt}`);
+        warnedNonConverging.add(warningKey);
+      }
+      continue;
+    }
+
     console.log(
       `[review-status-reconcile] re-emitting status for ${issueId} ` +
       '(canonical differs from last event — healing lost status_changed)',
@@ -65,6 +76,7 @@ async function reconcileOnce(): Promise<void> {
       issueId,
       canonical,
     );
+    lastHealedUpdatedAt.set(issueId, canonical.updatedAt);
   }
 }
 
@@ -85,6 +97,8 @@ export function stopReviewStatusReconcileService(): void {
     clearInterval(reconcileTimer);
     reconcileTimer = null;
   }
+  lastHealedUpdatedAt.clear();
+  warnedNonConverging.clear();
 }
 
 export async function __reconcileReviewStatusesOnceForTests(): Promise<void> {

--- a/src/dashboard/server/services/review-status-reconcile-service.ts
+++ b/src/dashboard/server/services/review-status-reconcile-service.ts
@@ -10,8 +10,7 @@ import {
 const POLL_INTERVAL_MS = 60_000;
 
 let reconcileTimer: ReturnType<typeof setInterval> | null = null;
-const lastHealedUpdatedAt = new Map<string, string>();
-const warnedNonConverging = new Set<string>();
+const reconcileTracking = new Map<string, { healedUpdatedAt: string; warnedUpdatedAt?: string }>();
 
 interface ReviewStatusEventPayload {
   issueId: string;
@@ -39,6 +38,9 @@ async function reconcileOnce(): Promise<void> {
     if (!canonical || canonical.retiredAt) continue;
     canonicalByIssue.set(issueId.toUpperCase(), canonical);
   }
+  for (const issueId of reconcileTracking.keys()) {
+    if (!canonicalByIssue.has(issueId)) reconcileTracking.delete(issueId);
+  }
 
   const store = getEventStore();
   const latestByIssue = new Map<string, StoredEvent>();
@@ -51,18 +53,24 @@ async function reconcileOnce(): Promise<void> {
     const latest = latestByIssue.get(issueId);
     const latestPayload = latest ? reviewStatusPayload(latest) : null;
     const lastUpdatedAt = latestPayload?.status.updatedAt ?? '';
-    if (lastUpdatedAt > canonical.updatedAt) continue;
+    if (lastUpdatedAt > canonical.updatedAt) {
+      reconcileTracking.delete(issueId);
+      continue;
+    }
     if (
       lastUpdatedAt === canonical.updatedAt &&
       latestPayload &&
       sameCanonicalReviewStatus(latestPayload.status, canonical)
-    ) continue;
+    ) {
+      reconcileTracking.delete(issueId);
+      continue;
+    }
 
-    if (lastHealedUpdatedAt.get(issueId) === canonical.updatedAt) {
-      const warningKey = `${issueId}:${canonical.updatedAt}`;
-      if (!warnedNonConverging.has(warningKey)) {
+    const tracking = reconcileTracking.get(issueId);
+    if (tracking?.healedUpdatedAt === canonical.updatedAt) {
+      if (tracking.warnedUpdatedAt !== canonical.updatedAt) {
         console.warn(`[review-status-reconcile] NOT CONVERGING for ${issueId}: canonical=${canonical.updatedAt} event=${lastUpdatedAt}`);
-        warnedNonConverging.add(warningKey);
+        tracking.warnedUpdatedAt = canonical.updatedAt;
       }
       continue;
     }
@@ -76,7 +84,7 @@ async function reconcileOnce(): Promise<void> {
       issueId,
       canonical,
     );
-    lastHealedUpdatedAt.set(issueId, canonical.updatedAt);
+    reconcileTracking.set(issueId, { healedUpdatedAt: canonical.updatedAt });
   }
 }
 
@@ -97,8 +105,7 @@ export function stopReviewStatusReconcileService(): void {
     clearInterval(reconcileTimer);
     reconcileTimer = null;
   }
-  lastHealedUpdatedAt.clear();
-  warnedNonConverging.clear();
+  reconcileTracking.clear();
 }
 
 export async function __reconcileReviewStatusesOnceForTests(): Promise<void> {

--- a/src/dashboard/server/services/uat-train.ts
+++ b/src/dashboard/server/services/uat-train.ts
@@ -134,7 +134,7 @@ function makeCleanupForProject(projectPath: string): () => Promise<void> {
     // none of them reachable from the wrapper path the monorepo cleanup uses.
     const projectConfig = findProjectByPathSync(projectPath);
     const cleanupGit = projectConfig?.workspace?.type === 'polyrepo'
-      ? buildPolyrepoCleanupGit(resolveProjectRepos(projectPath), projectPath)
+      ? buildPolyrepoCleanupGit(await resolveProjectRepos(projectPath), projectPath)
       : buildUatGenerationCleanupGit(projectPath);
 
     await cleanupUatGenerations(projectPath, {
@@ -170,7 +170,7 @@ async function runUatTrainReconcileForProject(
   }
 
   // Early exit if no candidates and no live generations — skip git operations
-  const candidates = listEligibleCandidatesByProject(projectPath);
+  const candidates = await listEligibleCandidatesByProject(projectPath);
   const liveGenerations = listUatGenerationsSync({
     projectRoot: projectPath,
     statuses: ['assembling', 'ready', 'superseded'],
@@ -240,7 +240,7 @@ async function runUatTrainReconcileForProject(
 async function getReadySetForProject(projectPath: string): Promise<ReadyFeature[] | null> {
   const { computeMergeQueueFromCandidates, listEligibleCandidatesByProject, resolveMergeQueuePrUrl } = await import('../../../lib/flywheel-merge-order.js');
 
-  const candidates = listEligibleCandidatesByProject(projectPath);
+  const candidates = await listEligibleCandidatesByProject(projectPath);
   if (candidates.length === 0) return [];
 
   const queue = await Effect.runPromise(
@@ -278,8 +278,8 @@ function resolveReposForIssue(issueId: string): ResolvedProjectRepo[] {
  * only the per-issue branch names differ, and callers here use the branches
  * from each feature's own contributions rather than these.
  */
-function resolveProjectRepos(projectPath: string, preferredIssueId?: string): ResolvedProjectRepo[] {
-  const issueId = preferredIssueId ?? listEligibleCandidatesByProject(projectPath)?.[0]?.issueId;
+async function resolveProjectRepos(projectPath: string, preferredIssueId?: string): Promise<ResolvedProjectRepo[]> {
+  const issueId = preferredIssueId ?? (await listEligibleCandidatesByProject(projectPath))[0]?.issueId;
   if (issueId) return resolveReposForIssue(issueId);
 
   // No candidate to resolve through — the exact state cleanup runs in after the
@@ -298,7 +298,7 @@ async function getPolyrepoReadySetForProject(projectPath: string): Promise<Ready
   const { computePolyrepoMergeQueueFromCandidates, listEligibleCandidatesByProject, resolveMergeQueuePrUrl } =
     await import('../../../lib/flywheel-merge-order.js');
 
-  const candidates = listEligibleCandidatesByProject(projectPath);
+  const candidates = await listEligibleCandidatesByProject(projectPath);
   if (candidates.length === 0) return [];
 
   const reposByIssue = new Map(candidates.map((c) => [c.issueId, resolveReposForIssue(c.issueId)]));
@@ -350,7 +350,7 @@ async function getPolyrepoBaseAnchor(
   const contributingKeys = new Set(
     (readySet ?? []).flatMap((f) => (f.repoContributions ?? []).map((c) => c.repoKey)),
   );
-  const repos = resolveProjectRepos(projectPath).filter((r) => contributingKeys.has(r.repoKey));
+  const repos = (await resolveProjectRepos(projectPath)).filter((r) => contributingKeys.has(r.repoKey));
   if (repos.length === 0) return '';
   const gitByRepo = buildPolyrepoGitDeps(repos);
 
@@ -389,7 +389,7 @@ async function assemblePolyrepoFromReadySetForProject(
   projectPath: string,
   features: readonly ReadyFeature[],
 ): Promise<UatGeneration> {
-  const repos = resolveProjectRepos(projectPath, features[0]?.issueId);
+  const repos = await resolveProjectRepos(projectPath, features[0]?.issueId);
   if (repos.length === 0) {
     throw new Error(`[uat-train] no member repos resolved for the polyrepo project at ${projectPath}`);
   }
@@ -765,7 +765,7 @@ export async function postUatGenerationPromotePayload(
   // and promote pushes to it. Fail closed rather than silently skipping a repo,
   // which would publish a partial batch.
   const writableKeys = polyrepo
-    ? new Set(resolveProjectRepos(root).filter((r) => r.required).map((r) => r.repoKey))
+    ? new Set((await resolveProjectRepos(root)).filter((r) => r.required).map((r) => r.repoKey))
     : new Set<string>();
   const nowReadOnly = polyrepo ? storedRepos.filter((r) => !writableKeys.has(r.repoKey)) : [];
   if (nowReadOnly.length > 0) {

--- a/src/dashboard/server/services/uat-train.ts
+++ b/src/dashboard/server/services/uat-train.ts
@@ -28,6 +28,7 @@ import {
   buildUatGenerationStore,
   buildUatGenerationCleanupGit,
   listRemoteUatBranches,
+  listRemoteUatBranchesMulti,
 } from '../../../lib/cloister/uat-generation-deps.js';
 import {
   assemblePolyrepoUatGeneration,
@@ -211,6 +212,13 @@ async function runUatTrainReconcileForProject(
       getBranchHeadSha: async () => '',
       getBaseAnchor: async () => getPolyrepoBaseAnchor(projectPath, await readySet()),
       getFeatureAnchor: (feature) => getPolyrepoFeatureAnchor(feature),
+      isGenerationContainedInMain: async (generation) => {
+        const repoGit = buildPolyrepoGitDeps(await resolveProjectRepos(projectPath));
+        const repos = generation.repos ?? [];
+        return repos.length > 0 && Promise.all(repos.map((repo) =>
+          repoGit.get(repo.repoKey)?.isBranchContainedInMain?.(repo.branch) ?? Promise.resolve(false)))
+          .then((contained) => contained.every(Boolean));
+      },
       store: buildUatGenerationStore(),
       assemble: (features) => assemblePolyrepoFromReadySetForProject(projectPath, features),
       teardownStack: (gen) => teardownUatStack(gen),
@@ -226,6 +234,7 @@ async function runUatTrainReconcileForProject(
     getReadySet: () => getReadySetForProject(projectPath),
     getMainHeadSha: () => gitDeps.fetchMain(),
     getBranchHeadSha: (branch) => gitDeps.branchHeadSha(branch),
+    isGenerationContainedInMain: (generation) => gitDeps.isBranchContainedInMain?.(generation.name) ?? Promise.resolve(false),
     store: buildUatGenerationStore(),
     assemble: (features) => assembleFromReadySetForProject(projectPath, features),
     teardownStack: (gen) => teardownUatStack(gen),
@@ -401,6 +410,7 @@ async function assemblePolyrepoFromReadySetForProject(
       dateIso: new Date().toISOString(),
       features,
       repos,
+      takenBranchNames: await listRemoteUatBranchesMulti(repos),
     },
     {
       repoGit: buildPolyrepoGitDeps(repos),

--- a/src/dashboard/server/services/uat-train.ts
+++ b/src/dashboard/server/services/uat-train.ts
@@ -213,7 +213,7 @@ async function runUatTrainReconcileForProject(
       getBaseAnchor: async () => getPolyrepoBaseAnchor(projectPath, await readySet()),
       getFeatureAnchor: (feature) => getPolyrepoFeatureAnchor(feature),
       isGenerationContainedInMain: async (generation) => {
-        const repoGit = buildPolyrepoGitDeps(await resolveProjectRepos(projectPath));
+        const repoGit = buildPolyrepoGitDeps(await resolveProjectRepos(projectPath), { includeReadOnly: true });
         const repos = generation.repos ?? [];
         return repos.length > 0 && Promise.all(repos.map((repo) =>
           repoGit.get(repo.repoKey)?.isBranchContainedInMain?.(repo.branch) ?? Promise.resolve(false)))

--- a/src/lib/cloister/deacon-merge.ts
+++ b/src/lib/cloister/deacon-merge.ts
@@ -17,6 +17,7 @@ import { isAgentIdleForNudge } from './agent-idle.js';
 import { loadCloisterConfig } from './config.js';
 import { getAutoCloseOutCanonicalState, sweepAutoCloseOutCache } from './deacon-canonical-state.js';
 import { isStuckMergingState, observeGitHubBranchMerge } from './deacon-stuck-merging.js';
+import { gatherMergeEligibility, isMergeEligible } from './merge-eligibility.js';
 
 export { reconcileStuckMergingStates } from './deacon-stuck-merging.js';
 export { reconcileAutoMergeRows } from './deacon-auto-merge-reconcile.js';
@@ -431,29 +432,42 @@ const STALE_MERGE_BLOCKER_COOLDOWN_MS = 2 * 60 * 1000; // 2 minutes
  * cooldown bounds the git-probe cost; resolveConflictGate also caches its
  * mergeability probe.
  */
-export async function reconcileStaleMergeBlockers(): Promise<string[]> {
+export async function reconcileStaleMergeBlockers(
+  gatherEligibility: typeof gatherMergeEligibility = gatherMergeEligibility,
+  workspaceExists: typeof existsSync = existsSync,
+  resolveWorkspace: (issueId: string) => string | null = (issueId) => {
+    const resolved = resolveProjectFromIssueSync(issueId);
+    return resolved
+      ? join(resolved.projectPath, 'workspaces', `feature-${issueId.toLowerCase()}`)
+      : null;
+  },
+): Promise<string[]> {
   const actions: string[] = [];
   try {
     const { resolveConflictGate, buildRealConflictGateDeps } = await import('./conflict-gate.js');
     const statuses = loadReviewStatuses();
     const now = Date.now();
     const deps = buildRealConflictGateDeps();
-
-    for (const [issueId, status] of Object.entries(statuses)) {
-      if (status.mergeStatus === 'merged') continue;
-      const hasMergeBlocker = (status.blockerReasons ?? []).some(
+    const candidates = Object.entries(statuses).filter(([, status]) =>
+      status.mergeStatus !== 'merged' && (status.blockerReasons ?? []).some(
         (b) => b.type === 'merge_conflict' || b.type === 'not_mergeable',
-      );
-      if (!hasMergeBlocker) continue;
+      ));
+    const memberships = await gatherEligibility(candidates.map(([issueId]) => issueId));
+
+    for (const [issueId] of candidates) {
 
       const cooledUntil = staleMergeBlockerCooldowns.get(issueId);
       if (cooledUntil && now < cooledUntil) continue;
       staleMergeBlockerCooldowns.set(issueId, now + STALE_MERGE_BLOCKER_COOLDOWN_MS);
 
-      const resolved = resolveProjectFromIssueSync(issueId);
-      if (!resolved) continue;
-      const workspacePath = join(resolved.projectPath, 'workspaces', `feature-${issueId.toLowerCase()}`);
-      if (!existsSync(workspacePath)) continue;
+      const membership = memberships.get(issueId.toUpperCase());
+      if (!membership || !isMergeEligible(membership)) {
+        console.log(`[deacon] skipping ${issueId} — pipeline membership is ${membership?.bucket ?? 'unavailable'}, not merge-eligible`);
+        continue;
+      }
+      const workspacePath = resolveWorkspace(issueId);
+      if (!workspacePath) continue;
+      if (!workspaceExists(workspacePath)) continue;
 
       try {
         const result = await resolveConflictGate(issueId, workspacePath, 'main', deps);
@@ -493,13 +507,22 @@ export async function reconcileStaleMergeBlockers(): Promise<string[]> {
  * issue, so steady state is zero writes. Flipping readyForMerge=true only makes
  * the issue merge-ELIGIBLE; the merge train / MERGE button remains the trigger.
  */
-export function reconcileStuckReadyForMerge(): string[] {
+export async function reconcileStuckReadyForMerge(
+  gatherEligibility: typeof gatherMergeEligibility = gatherMergeEligibility,
+): Promise<string[]> {
   const actions: string[] = [];
   try {
-    for (const [issueId, status] of Object.entries(loadReviewStatuses())) {
-      if (status.readyForMerge !== false) continue;
-      if ((status.blockerReasons?.length ?? 0) > 0) continue; // blocker strand → reconcileStaleMergeBlockers
-      if (!reviewGatesPassedSync(status)) continue;
+    const candidates = Object.entries(loadReviewStatuses()).filter(([, status]) =>
+      status.readyForMerge === false
+      && (status.blockerReasons?.length ?? 0) === 0
+      && reviewGatesPassedSync(status));
+    const memberships = await gatherEligibility(candidates.map(([issueId]) => issueId));
+    for (const [issueId] of candidates) {
+      const membership = memberships.get(issueId.toUpperCase());
+      if (!membership || !isMergeEligible(membership)) {
+        console.log(`[deacon] skipping ${issueId} — pipeline membership is ${membership?.bucket ?? 'unavailable'}, not merge-eligible`);
+        continue;
+      }
       setReviewStatusSync(issueId, { readyForMerge: true });
       const msg = `Restored readyForMerge for ${issueId} — review+test+verify passed, no blocker (was stuck false)`;
       actions.push(msg);

--- a/src/lib/cloister/deacon-merge.ts
+++ b/src/lib/cloister/deacon-merge.ts
@@ -490,22 +490,9 @@ export async function reconcileStaleMergeBlockers(
  * Reconciler (PAN-2198): periodic twin of the boot-only fixStuckReadyForMerge,
  * for the NO-BLOCKER strand of "stuck after review".
  *
- * readyForMerge is re-derived on every setReviewStatusSync write. When the last
- * write left it false and there is NO merge-blocker, nothing re-derives it until
- * the next write — so a PR whose review+test+verify all passed but whose
- * readyForMerge was left false (e.g. a verdict that landed via a write path that
- * didn't recompute, or a gate that was transiently non-final) converges ONLY on
- * server restart (PAN-1758: "readyForMerge only flips via the startup repair
- * sweep"). This patrol re-derives it on the 60s deacon tick instead.
- *
- * Blocker strands are deliberately excluded — those are owned by
- * reconcileStaleMergeBlockers, and excluding them also avoids fighting the
- * setReviewStatus deriver's hasBlockers override (which would flip readyForMerge
- * straight back to false). Loop-safe: it writes ONLY readyForMerge (no
- * review/test status transition, so no review/test re-dispatch events fire), and
- * is idempotent — once flipped true, the readyForMerge!==false guard excludes the
- * issue, so steady state is zero writes. Flipping readyForMerge=true only makes
- * the issue merge-ELIGIBLE; the merge train / MERGE button remains the trigger.
+ * Blocker strands remain owned by reconcileStaleMergeBlockers. This patrol is
+ * idempotent because a restored record no longer matches readyForMerge=false.
+ * Membership now prevents it from restoring issues without an open PR.
  */
 export async function reconcileStuckReadyForMerge(
   gatherEligibility: typeof gatherMergeEligibility = gatherMergeEligibility,

--- a/src/lib/cloister/deacon-merge.ts
+++ b/src/lib/cloister/deacon-merge.ts
@@ -388,7 +388,7 @@ export async function reconcileClosedPrReadyForMerge(): Promise<string[]> {
         } else {
           setReviewStatusSync(issueId, {
             readyForMerge: false,
-            mergeStatus: 'failed',
+            retiredAt: new Date(now).toISOString(),
             mergeNotes: `PR #${prNumber} was closed without merging — reopen the PR or reset review state to re-queue this issue`,
           });
           const msg = `Reset readyForMerge for ${issueId} — PR #${prNumber} is ${prState.state} (not OPEN)`;
@@ -455,13 +455,13 @@ export async function reconcileStaleMergeBlockers(
     const memberships = await gatherEligibility(candidates.map(([issueId]) => issueId));
 
     for (const [issueId] of candidates) {
-
       const cooledUntil = staleMergeBlockerCooldowns.get(issueId);
       if (cooledUntil && now < cooledUntil) continue;
       staleMergeBlockerCooldowns.set(issueId, now + STALE_MERGE_BLOCKER_COOLDOWN_MS);
 
       const membership = memberships.get(issueId.toUpperCase());
       if (!membership || !isMergeEligible(membership)) {
+        if (membership) setReviewStatusSync(issueId, { readyForMerge: false, retiredAt: new Date(now).toISOString() });
         console.log(`[deacon] skipping ${issueId} — pipeline membership is ${membership?.bucket ?? 'unavailable'}, not merge-eligible`);
         continue;
       }
@@ -490,9 +490,8 @@ export async function reconcileStaleMergeBlockers(
  * Reconciler (PAN-2198): periodic twin of the boot-only fixStuckReadyForMerge,
  * for the NO-BLOCKER strand of "stuck after review".
  *
- * Blocker strands remain owned by reconcileStaleMergeBlockers. This patrol is
- * idempotent because a restored record no longer matches readyForMerge=false.
- * Membership now prevents it from restoring issues without an open PR.
+ * Blocker strands remain owned by reconcileStaleMergeBlockers. Membership
+ * prevents restoration without an open PR; successful restoration is idempotent.
  */
 export async function reconcileStuckReadyForMerge(
   gatherEligibility: typeof gatherMergeEligibility = gatherMergeEligibility,
@@ -507,6 +506,7 @@ export async function reconcileStuckReadyForMerge(
     for (const [issueId] of candidates) {
       const membership = memberships.get(issueId.toUpperCase());
       if (!membership || !isMergeEligible(membership)) {
+        if (membership) setReviewStatusSync(issueId, { readyForMerge: false, retiredAt: new Date().toISOString() });
         console.log(`[deacon] skipping ${issueId} — pipeline membership is ${membership?.bucket ?? 'unavailable'}, not merge-eligible`);
         continue;
       }

--- a/src/lib/cloister/deacon-merge.ts
+++ b/src/lib/cloister/deacon-merge.ts
@@ -155,7 +155,7 @@ export async function reconcileStaleMergeStatus(): Promise<string[]> {
 
     for (const [issueId, status] of Object.entries(statuses)) {
       const postMergeIncomplete = status.mergeStatus === 'merged' && status.mergeStep === 'post-merge-cleanup';
-      if (status.mergeStatus === 'merged' && !postMergeIncomplete) continue;
+      if (status.retiredAt || (status.mergeStatus === 'merged' && !postMergeIncomplete)) continue;
       if (isStuckMergingState(status, Date.now())) continue;
       if (!postMergeIncomplete && staleMergeReconciled.has(issueId)) continue;
 
@@ -289,7 +289,7 @@ export async function reconcileFalseMerged(): Promise<string[]> {
     const statuses = loadReviewStatuses();
 
     for (const [issueId, status] of Object.entries(statuses)) {
-      if (status.mergeStatus !== 'merged') continue;
+      if (status.retiredAt || status.mergeStatus !== 'merged') continue;
       if (!status.prUrl) continue;
       if (falseMergedReset.has(issueId)) continue;
 
@@ -360,7 +360,7 @@ export async function reconcileClosedPrReadyForMerge(): Promise<string[]> {
     const now = Date.now();
 
     for (const [issueId, status] of Object.entries(statuses)) {
-      if (!status.readyForMerge) continue;
+      if (status.retiredAt || !status.readyForMerge) continue;
       if (!status.prUrl) continue;
 
       const cooledUntil = closedPrReadyReconcileCooldowns.get(issueId);
@@ -449,7 +449,7 @@ export async function reconcileStaleMergeBlockers(
     const now = Date.now();
     const deps = buildRealConflictGateDeps();
     const candidates = Object.entries(statuses).filter(([, status]) =>
-      status.mergeStatus !== 'merged' && (status.blockerReasons ?? []).some(
+      !status.retiredAt && status.mergeStatus !== 'merged' && (status.blockerReasons ?? []).some(
         (b) => b.type === 'merge_conflict' || b.type === 'not_mergeable',
       ));
     const memberships = await gatherEligibility(candidates.map(([issueId]) => issueId));
@@ -489,7 +489,6 @@ export async function reconcileStaleMergeBlockers(
 /**
  * Reconciler (PAN-2198): periodic twin of the boot-only fixStuckReadyForMerge,
  * for the NO-BLOCKER strand of "stuck after review".
- *
  * Blocker strands remain owned by reconcileStaleMergeBlockers. Membership
  * prevents restoration without an open PR; successful restoration is idempotent.
  */
@@ -499,7 +498,8 @@ export async function reconcileStuckReadyForMerge(
   const actions: string[] = [];
   try {
     const candidates = Object.entries(loadReviewStatuses()).filter(([, status]) =>
-      status.readyForMerge === false
+      !status.retiredAt
+      && status.readyForMerge === false
       && (status.blockerReasons?.length ?? 0) === 0
       && reviewGatesPassedSync(status));
     const memberships = await gatherEligibility(candidates.map(([issueId]) => issueId));
@@ -528,7 +528,7 @@ export async function reconcileMergedButReviewing(): Promise<string[]> {
     const nonTerminal = new Set(['reviewing', 'pending', undefined, null]);
 
     for (const [issueId, status] of Object.entries(statuses)) {
-      if (status.mergeStatus !== 'merged') continue;
+      if (status.retiredAt || status.mergeStatus !== 'merged') continue;
       const reviewNonTerminal = nonTerminal.has(status.reviewStatus as string | undefined);
       const testNonTerminal = nonTerminal.has(status.testStatus as string | undefined);
       if (!reviewNonTerminal && !testNonTerminal) continue;

--- a/src/lib/cloister/deacon-merge.ts
+++ b/src/lib/cloister/deacon-merge.ts
@@ -17,14 +17,12 @@ import { isAgentIdleForNudge } from './agent-idle.js';
 import { loadCloisterConfig } from './config.js';
 import { getAutoCloseOutCanonicalState, sweepAutoCloseOutCache } from './deacon-canonical-state.js';
 import { isStuckMergingState, observeGitHubBranchMerge } from './deacon-stuck-merging.js';
-import { gatherMergeEligibility, isMergeEligible } from './merge-eligibility.js';
 
 export { reconcileStuckMergingStates } from './deacon-stuck-merging.js';
 export { reconcileAutoMergeRows } from './deacon-auto-merge-reconcile.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
-
 interface MergeReminderState {
   mergeStuckAttempts?: Record<string, number>;
 }
@@ -433,7 +431,8 @@ const STALE_MERGE_BLOCKER_COOLDOWN_MS = 2 * 60 * 1000; // 2 minutes
  * mergeability probe.
  */
 export async function reconcileStaleMergeBlockers(
-  gatherEligibility: typeof gatherMergeEligibility = gatherMergeEligibility,
+  gatherEligibility: typeof import('./merge-eligibility.js').gatherMergeEligibility = async (ids) =>
+    (await import('./merge-eligibility.js')).gatherMergeEligibility(ids),
   workspaceExists: typeof existsSync = existsSync,
   resolveWorkspace: (issueId: string) => string | null = (issueId) => {
     const resolved = resolveProjectFromIssueSync(issueId);
@@ -460,7 +459,7 @@ export async function reconcileStaleMergeBlockers(
       staleMergeBlockerCooldowns.set(issueId, now + STALE_MERGE_BLOCKER_COOLDOWN_MS);
 
       const membership = memberships.get(issueId.toUpperCase());
-      if (!membership || !isMergeEligible(membership)) {
+      if (!membership || membership.bucket !== 'in_flight') {
         if (membership) setReviewStatusSync(issueId, { readyForMerge: false, retiredAt: new Date(now).toISOString() });
         console.log(`[deacon] skipping ${issueId} — pipeline membership is ${membership?.bucket ?? 'unavailable'}, not merge-eligible`);
         continue;
@@ -493,7 +492,8 @@ export async function reconcileStaleMergeBlockers(
  * prevents restoration without an open PR; successful restoration is idempotent.
  */
 export async function reconcileStuckReadyForMerge(
-  gatherEligibility: typeof gatherMergeEligibility = gatherMergeEligibility,
+  gatherEligibility: typeof import('./merge-eligibility.js').gatherMergeEligibility = async (ids) =>
+    (await import('./merge-eligibility.js')).gatherMergeEligibility(ids),
 ): Promise<string[]> {
   const actions: string[] = [];
   try {
@@ -505,7 +505,7 @@ export async function reconcileStuckReadyForMerge(
     const memberships = await gatherEligibility(candidates.map(([issueId]) => issueId));
     for (const [issueId] of candidates) {
       const membership = memberships.get(issueId.toUpperCase());
-      if (!membership || !isMergeEligible(membership)) {
+      if (!membership || membership.bucket !== 'in_flight') {
         if (membership) setReviewStatusSync(issueId, { readyForMerge: false, retiredAt: new Date().toISOString() });
         console.log(`[deacon] skipping ${issueId} — pipeline membership is ${membership?.bucket ?? 'unavailable'}, not merge-eligible`);
         continue;

--- a/src/lib/cloister/deacon.ts
+++ b/src/lib/cloister/deacon.ts
@@ -3051,7 +3051,7 @@ export async function runPatrol(): Promise<PatrolResult> {
   // PAN-2198: re-derive readyForMerge for the no-blocker "stuck after review" strand
   // (review+test+verify passed, no blocker, but readyForMerge stuck false) so it
   // converges on the deacon tick instead of only on the server-restart repair sweep.
-  const stuckReadyActions = reconcileStuckReadyForMerge();
+  const stuckReadyActions = await reconcileStuckReadyForMerge();
   actions.push(...stuckReadyActions);
   for (const a of stuckReadyActions) addLog('action', a, state.patrolCycle);
 

--- a/src/lib/cloister/merge-eligibility.ts
+++ b/src/lib/cloister/merge-eligibility.ts
@@ -1,0 +1,60 @@
+import { gatherProjectLensSignals } from '../pipeline-membership-gather.js';
+import {
+  resolvePipelineMembership,
+  type PipelineMembership,
+} from '../pipeline-membership.js';
+import {
+  getProjectSync,
+  resolveProjectFromIssueSync,
+  type ProjectConfig,
+} from '../projects.js';
+
+export interface MergeEligibilityDeps {
+  resolveProject: typeof resolveProjectFromIssueSync;
+  getProject: typeof getProjectSync;
+  gather: typeof gatherProjectLensSignals;
+}
+
+const defaultDeps: MergeEligibilityDeps = {
+  resolveProject: resolveProjectFromIssueSync,
+  getProject: getProjectSync,
+  gather: gatherProjectLensSignals,
+};
+
+export function isMergeEligible(membership: PipelineMembership): boolean {
+  return membership.bucket === 'in_flight';
+}
+
+/** Classify candidates through one durable-lens gather per represented project. */
+export async function gatherMergeEligibility(
+  issueIds: string[],
+  deps: MergeEligibilityDeps = defaultDeps,
+): Promise<Map<string, PipelineMembership>> {
+  const candidatesByProject = new Map<string, { project: ProjectConfig; issueIds: Set<string> }>();
+
+  for (const issueId of issueIds) {
+    const resolved = deps.resolveProject(issueId);
+    if (!resolved) continue;
+    const configured = deps.getProject(resolved.projectKey);
+    if (!configured) continue;
+    const existing = candidatesByProject.get(resolved.projectKey);
+    if (existing) {
+      existing.issueIds.add(issueId.toUpperCase());
+    } else {
+      candidatesByProject.set(resolved.projectKey, {
+        project: { ...configured, path: resolved.projectPath },
+        issueIds: new Set([issueId.toUpperCase()]),
+      });
+    }
+  }
+
+  const memberships = new Map<string, PipelineMembership>();
+  await Promise.all([...candidatesByProject.values()].map(async ({ project, issueIds: candidates }) => {
+    const signals = await deps.gather(project);
+    for (const signal of signals) {
+      const issueId = signal.issueId.toUpperCase();
+      if (candidates.has(issueId)) memberships.set(issueId, resolvePipelineMembership(signal));
+    }
+  }));
+  return memberships;
+}

--- a/src/lib/cloister/uat-candidate-name.ts
+++ b/src/lib/cloister/uat-candidate-name.ts
@@ -44,6 +44,16 @@ export function makeUatCandidateName(deps: UatNameDeps): string {
   return `uat/${deps.label}-${word}-${day}`;
 }
 
+/** Keep the deterministic first name, then mint -2, -3, … around durable collisions. */
+export function makeUniqueUatCandidateName(deps: UatNameDeps, takenNames: Iterable<string>): string {
+  const base = makeUatCandidateName(deps);
+  const taken = new Set(takenNames);
+  if (!taken.has(base)) return base;
+  let suffix = 2;
+  while (taken.has(`${base}-${suffix}`)) suffix += 1;
+  return `${base}-${suffix}`;
+}
+
 function stableIndex(seed: string, modulo: number): number {
   if (modulo <= 0) return 0;
   let hash = 2166136261;

--- a/src/lib/cloister/uat-generation-deps.ts
+++ b/src/lib/cloister/uat-generation-deps.ts
@@ -264,14 +264,15 @@ export function featureNamespaceOf(sourceBranch: string): string {
  */
 export function buildPolyrepoGitDeps(
   repos: readonly ResolvedProjectRepo[],
+  /** Containment-only callers include read-only repos recorded on old generations. */
+  options: { includeReadOnly?: boolean } = {},
 ): Map<string, PolyrepoRepoGit> {
   return new Map(
     repos
       // A repo configured `readonly: true` (required === false) is never a
-      // write target. Omitting it here means assembly cannot branch or push to
-      // it even if a caller passes it in — the ready-set filter is the first
-      // line of defense, this is the second.
-      .filter((repo) => repo.required)
+      // write target. Assembly uses the default filter; terminal containment
+      // opts in because historical generations can record read-only repos.
+      .filter((repo) => repo.required || options.includeReadOnly)
       .map((repo) => {
         let worktreePath = '';
         let generationBranch = '';

--- a/src/lib/cloister/uat-generation-deps.ts
+++ b/src/lib/cloister/uat-generation-deps.ts
@@ -36,7 +36,7 @@ const runGit = (args: string[], cwd: string) =>
  * contributions throw and get held out. The character class is unchanged, so
  * shell metacharacters and path traversal are still refused.
  */
-function safeBranchName(
+export function safeBranchName(
   branchName: string,
   prefix: 'feature' | 'uat',
   featurePrefix = 'feature/',
@@ -50,7 +50,7 @@ function safeBranchName(
   return branchName;
 }
 
-function safeGenerationWorktreePath(projectRoot: string, worktreePath: string): string {
+export function safeGenerationWorktreePath(projectRoot: string, worktreePath: string): string {
   const workspacesRoot = resolve(projectRoot, 'workspaces');
   const target = resolve(worktreePath);
   const rel = relative(workspacesRoot, target);
@@ -124,6 +124,16 @@ export function buildUatGenerationGitDeps(
       const safeBranch = safeBranchName(branch, 'feature', featurePrefix);
       const tryRef = async (ref: string) => (await runGit(['rev-parse', ref], projectRoot)).stdout.trim();
       return tryRef(`origin/${safeBranch}`).catch(() => tryRef(safeBranch));
+    },
+
+    isBranchContainedInMain: async (branch) => {
+      const safeBranch = safeBranchName(branch, 'uat');
+      const ref = await runGit(['rev-parse', '--verify', `origin/${safeBranch}`], projectRoot)
+        .then(() => `origin/${safeBranch}`)
+        .catch(() => safeBranch);
+      return runGit(['merge-base', '--is-ancestor', ref, originTarget], projectRoot)
+        .then(() => true)
+        .catch(() => false);
     },
 
     mergeBranch: async (featureBranch) => {

--- a/src/lib/cloister/uat-generation-engine.ts
+++ b/src/lib/cloister/uat-generation-engine.ts
@@ -16,7 +16,7 @@
  * uat-generation-deps.ts for the real wiring), so every path — happy,
  * conflict-resolved, held-out, failed — is unit-testable with fake deps.
  */
-import { makeUatCandidateName } from './uat-candidate-name.js';
+import { makeUniqueUatCandidateName } from './uat-candidate-name.js';
 import {
   applyUnionLintPlan,
   planUnionLint,
@@ -81,6 +81,8 @@ export interface GenerationGitDeps {
   createWorktree(branchName: string, worktreePath: string): Promise<void>;
   /** Head SHA of a feature branch (origin-first). */
   branchHeadSha(branch: string): Promise<string>;
+  /** Whether a UAT branch tip is already contained in the target branch. */
+  isBranchContainedInMain?(branch: string): Promise<boolean>;
   /**
    * Merge a feature branch into the generation worktree. On conflict the
    * worktree is left MID-CONFLICT (the hook needs that state); the engine
@@ -164,10 +166,10 @@ export async function assembleUatGeneration(
   const log = deps.log ?? (() => {});
 
   const baseSha = await deps.git.fetchMain();
-  const name = makeUatCandidateName({
+  const name = makeUniqueUatCandidateName({
     label: input.label,
     dateIso: input.dateIso,
-  });
+  }, [...deps.store.listNames(), ...(input.takenBranchNames ?? [])]);
   const worktreePath = `${input.projectRoot}/workspaces/${generationFolderName(name)}`;
 
   deps.store.insert({

--- a/src/lib/cloister/uat-polyrepo-engine.ts
+++ b/src/lib/cloister/uat-polyrepo-engine.ts
@@ -23,7 +23,7 @@
  * conflict-resolved, held-out, push-failed — is unit-testable with fake deps.
  */
 
-import { makeUatCandidateName } from './uat-candidate-name.js';
+import { makeUniqueUatCandidateName } from './uat-candidate-name.js';
 import { generationFolderName } from './uat-generation-engine.js';
 import {
   applyUnionLintPlan,
@@ -66,6 +66,7 @@ export interface PolyrepoAssembleInput {
   features: readonly ReadyFeature[];
   /** Every configured member repo for the project. */
   repos: readonly ResolvedProjectRepo[];
+  takenBranchNames?: readonly string[];
 }
 
 /**
@@ -222,7 +223,10 @@ export async function assemblePolyrepoUatGeneration(
   deps: PolyrepoAssembleDeps,
 ): Promise<UatGeneration> {
   const log = deps.log ?? (() => {});
-  const name = makeUatCandidateName({ label: input.label, dateIso: input.dateIso });
+  const name = makeUniqueUatCandidateName(
+    { label: input.label, dateIso: input.dateIso },
+    [...deps.store.listNames(), ...(input.takenBranchNames ?? [])],
+  );
   const worktreePath = `${input.projectRoot}/workspaces/${generationFolderName(name)}`;
   const repoWorktree = (repoKey: string) => `${worktreePath}/${repoKey}`;
 

--- a/src/lib/cloister/uat-reconciler.ts
+++ b/src/lib/cloister/uat-reconciler.ts
@@ -63,6 +63,8 @@ export interface UatReconcilerDeps {
    * the single branch head SHA. Omit for monorepo.
    */
   getFeatureAnchor?(feature: ReadyFeature): Promise<string>;
+  /** Positive merge evidence for a generation branch; omitted when unavailable. */
+  isGenerationContainedInMain?(generation: UatGeneration): Promise<boolean>;
   store: GenerationStorePort;
   /** Assemble the next generation from the desired set (the engine). */
   assemble(features: readonly ReadyFeature[]): Promise<UatGeneration>;
@@ -195,8 +197,14 @@ export async function reconcileUatGenerations(
     }
     const desiredIds = new Set(readySet.map((f) => f.issueId.toUpperCase()));
 
-    // 1. Invalidate stale live generations (stack teardown included).
+    // Promoted is terminal: stamp positive merge evidence before stale checks,
+    // and never include promoted rows in the live list passed to isStale.
     for (const gen of deps.store.listChain(projectRoot, ['ready', 'superseded'])) {
+      if (await deps.isGenerationContainedInMain?.(gen).catch(() => false)) {
+        log(`[uat-reconciler] stamping ${gen.name} promoted — branch is contained in main`);
+        deps.store.update(gen.name, { status: 'promoted' });
+        continue;
+      }
       const staleReason = isStale(gen, desiredIds, headShas);
       if (!staleReason) continue;
       log(`[uat-reconciler] invalidating ${gen.name}: ${staleReason}`);

--- a/src/lib/database/__tests__/pending-auto-merges-schema.test.ts
+++ b/src/lib/database/__tests__/pending-auto-merges-schema.test.ts
@@ -30,7 +30,7 @@ describe('pending auto-merges schema', { timeout: 30_000 }, () => {
   it('uses current schema version and creates pending_auto_merges on fresh init', () => {
     makeTestHome('pan-pending-auto-merges-fresh');
 
-    expect(SCHEMA_VERSION).toBe(64);
+    expect(SCHEMA_VERSION).toBe(65);
     const db = getDatabase();
     expect(db.pragma('user_version', { simple: true })).toBe(SCHEMA_VERSION);
 

--- a/src/lib/database/review-status-db.ts
+++ b/src/lib/database/review-status-db.ts
@@ -66,9 +66,9 @@ export function upsertReviewStatusSync(status: ReviewStatus): void {
         last_verified_commit,
         merge_step,
         auto_merge,
-        review_cycle_history
+        review_cycle_history, retired_at
       ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
       )
       ON CONFLICT(issue_id) DO UPDATE SET
         review_status         = excluded.review_status,
@@ -113,7 +113,8 @@ export function upsertReviewStatusSync(status: ReviewStatus): void {
         last_verified_commit  = excluded.last_verified_commit,
         merge_step            = excluded.merge_step,
         auto_merge            = excluded.auto_merge,
-        review_cycle_history  = excluded.review_cycle_history
+        review_cycle_history  = excluded.review_cycle_history,
+        retired_at            = excluded.retired_at
     `).run(
       s.issueId,
       s.reviewStatus,
@@ -159,6 +160,7 @@ export function upsertReviewStatusSync(status: ReviewStatus): void {
       s.mergeStep ?? null,
       s.autoMerge === undefined ? null : (s.autoMerge ? 1 : 0),
       s.reviewCycleHistory ? JSON.stringify(s.reviewCycleHistory) : null,
+      s.retiredAt ?? null,
     );
 
     // Append new history entries (deduplicate by timestamp to avoid re-inserting)
@@ -433,6 +435,7 @@ interface DbReviewStatusRow {
   release_notes: string | null;
   updated_at: string;
   ready_for_merge: number;
+  retired_at: string | null;
   auto_requeue_count: number | null;
   merge_retry_count: number | null;
   pr_url: string | null;
@@ -495,6 +498,7 @@ function rowToReviewStatus(row: DbReviewStatusRow, history: StatusHistoryEntry[]
     releaseNotes: row.release_notes ?? undefined,
     updatedAt: row.updated_at,
     readyForMerge: row.ready_for_merge === 1,
+    retiredAt: row.retired_at ?? undefined,
     autoRequeueCount: row.auto_requeue_count ?? undefined,
     mergeRetryCount: row.merge_retry_count ?? undefined,
     prUrl: row.pr_url ?? undefined,

--- a/src/lib/database/review-status-db.ts
+++ b/src/lib/database/review-status-db.ts
@@ -250,9 +250,10 @@ export function getMergeBlockerReconcileCandidatesSync(): MergeBlockerReconcileC
   const rows = db.prepare(`
     SELECT issue_id, pr_url, blocker_reasons, ready_for_merge
     FROM review_status
-    WHERE ready_for_merge = 1
+    WHERE retired_at IS NULL AND (
+      ready_for_merge = 1
       OR blocker_reasons LIKE '%merge_conflict%'
-      OR blocker_reasons LIKE '%not_mergeable%'
+      OR blocker_reasons LIKE '%not_mergeable%')
   `).all() as Array<{
     issue_id: string;
     pr_url: string | null;

--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -11,7 +11,7 @@ import { encodeClaudeProjectDir, getOverdeckHome } from '../paths.js';
 import { backfillAgentsFromStateJsonSync } from './agent-backfill.js';
 
 // Schema version — increment when making breaking schema changes
-export const SCHEMA_VERSION = 64;
+export const SCHEMA_VERSION = 65;
 
 function tryIdempotentDdl(db: SqliteDatabase, targetVersion: number, statement: string): void {
   try {
@@ -234,6 +234,7 @@ export function initSchema(db: SqliteDatabase): void {
       release_notes         TEXT,
       updated_at            TEXT NOT NULL,
       ready_for_merge       INTEGER NOT NULL DEFAULT 0,
+      retired_at            TEXT,
       auto_requeue_count    INTEGER DEFAULT 0,
       merge_retry_count     INTEGER DEFAULT 0,
       pr_url                TEXT,
@@ -1756,6 +1757,11 @@ export function runMigrations(db: SqliteDatabase, dbPath?: string): void {
   if (currentVersion < 64) {
     tryIdempotentDdl(db, 64, 'ALTER TABLE review_status ADD COLUMN uat_status TEXT');
     tryIdempotentDdl(db, 64, 'ALTER TABLE review_status ADD COLUMN uat_notes TEXT');
+  }
+
+  // v64 -> v65: terminal marker for review records whose PR is no longer actionable.
+  if (currentVersion < 65) {
+    tryIdempotentDdl(db, 65, 'ALTER TABLE review_status ADD COLUMN retired_at TEXT');
   }
 
   // After all migrations, set the version

--- a/src/lib/database/schema.ts
+++ b/src/lib/database/schema.ts
@@ -1753,17 +1753,11 @@ export function runMigrations(db: SqliteDatabase, dbPath?: string): void {
     tryIdempotentDdl(db, 63, 'ALTER TABLE review_status ADD COLUMN conflicts_since TEXT');
   }
 
-  // v63 -> v64: persist browser UAT independently from automated test gates (PAN-3365).
   if (currentVersion < 64) {
     tryIdempotentDdl(db, 64, 'ALTER TABLE review_status ADD COLUMN uat_status TEXT');
     tryIdempotentDdl(db, 64, 'ALTER TABLE review_status ADD COLUMN uat_notes TEXT');
   }
-
-  // v64 -> v65: terminal marker for review records whose PR is no longer actionable.
-  if (currentVersion < 65) {
-    tryIdempotentDdl(db, 65, 'ALTER TABLE review_status ADD COLUMN retired_at TEXT');
-  }
-
+  if (currentVersion < 65) tryIdempotentDdl(db, 65, 'ALTER TABLE review_status ADD COLUMN retired_at TEXT');
   // After all migrations, set the version
   db.pragma(`user_version = ${SCHEMA_VERSION}`);
 }

--- a/src/lib/flywheel-merge-order.ts
+++ b/src/lib/flywheel-merge-order.ts
@@ -2,7 +2,6 @@ import { Effect } from 'effect';
 import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process';
 import type { FlywheelPipelineItem } from '@overdeck/contracts';
 import { getReviewStatusSync, loadReviewStatuses, mergeGateEligibility, type MergeGateEligibility } from './review-status.js';
-import { gatherMergeEligibility, isMergeEligible } from './cloister/merge-eligibility.js';
 import { resolveGitHubIssueSync } from './tracker-utils.js';
 import type { SequenceNode } from './backlog/types.js';
 import { classifyIssue, isAutoPickable, type ClassifyLookups } from './backlog/pickup.js';
@@ -256,6 +255,7 @@ export async function listEligibleCandidatesByProject(projectRoot: string): Prom
     return issueProject?.projectPath === project.path &&
       rs.deaconIgnored !== true && rs.readyForMerge === true && mergeGateEligibility(rs).eligible;
   });
+  const { gatherMergeEligibility, isMergeEligible } = await import('./cloister/merge-eligibility.js');
   const memberships = await gatherMergeEligibility(readyStatuses.map(([issueId]) => issueId));
   const candidates: Array<{ issueId: string; title: string; pr?: number }> = [];
 

--- a/src/lib/flywheel-merge-order.ts
+++ b/src/lib/flywheel-merge-order.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect';
 import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process';
 import type { FlywheelPipelineItem } from '@overdeck/contracts';
 import { getReviewStatusSync, loadReviewStatuses, mergeGateEligibility, type MergeGateEligibility } from './review-status.js';
+import { gatherMergeEligibility, isMergeEligible } from './cloister/merge-eligibility.js';
 import { resolveGitHubIssueSync } from './tracker-utils.js';
 import type { SequenceNode } from './backlog/types.js';
 import { classifyIssue, isAutoPickable, type ClassifyLookups } from './backlog/pickup.js';
@@ -245,25 +246,23 @@ export function resolveMergeQueuePrUrl(item: { issueId: string; pr?: number }): 
  * No flywheel run required — sources directly from persistent pipeline state.
  * Returns an array of candidate items compatible with computeMergeQueueFromCandidates.
  */
-export function listEligibleCandidatesByProject(projectRoot: string): Array<{ issueId: string; title: string; pr?: number }> {
+export async function listEligibleCandidatesByProject(projectRoot: string): Promise<Array<{ issueId: string; title: string; pr?: number }>> {
   const project = findProjectByPathSync(projectRoot);
   if (!project) return [];
 
-  const candidates: Array<{ issueId: string; title: string; pr?: number }> = [];
   const allStatuses = loadReviewStatuses();
+  const readyStatuses = Object.entries(allStatuses).filter(([, rs]) =>
+    rs.deaconIgnored !== true && rs.readyForMerge === true && mergeGateEligibility(rs).eligible);
+  const memberships = await gatherMergeEligibility(readyStatuses.map(([issueId]) => issueId));
+  const candidates: Array<{ issueId: string; title: string; pr?: number }> = [];
 
-  for (const [issueId, rs] of Object.entries(allStatuses)) {
+  for (const [issueId, rs] of readyStatuses) {
     // Check if this issue belongs to this project
     const issueProject = resolveProjectFromIssueSync(issueId);
     if (!issueProject || issueProject.projectPath !== project.path) continue;
 
-    // Exclude deacon-ignored issues (AC 8)
-    if (rs.deaconIgnored === true) continue;
-
-    // Check if it's merge-eligible
-    if (rs.readyForMerge !== true) continue;
-    const eligibility = mergeGateEligibility(rs);
-    if (!eligibility.eligible) continue;
+    const membership = memberships.get(issueId.toUpperCase());
+    if (!membership || !isMergeEligible(membership)) continue;
 
     // AC 10: title resolved downstream by computeMergeQueueFromCandidates; here use issue ID
     candidates.push({ issueId, title: issueId, pr: rs.prNumber });

--- a/src/lib/flywheel-merge-order.ts
+++ b/src/lib/flywheel-merge-order.ts
@@ -251,16 +251,15 @@ export async function listEligibleCandidatesByProject(projectRoot: string): Prom
   if (!project) return [];
 
   const allStatuses = loadReviewStatuses();
-  const readyStatuses = Object.entries(allStatuses).filter(([, rs]) =>
-    rs.deaconIgnored !== true && rs.readyForMerge === true && mergeGateEligibility(rs).eligible);
+  const readyStatuses = Object.entries(allStatuses).filter(([issueId, rs]) => {
+    const issueProject = resolveProjectFromIssueSync(issueId);
+    return issueProject?.projectPath === project.path &&
+      rs.deaconIgnored !== true && rs.readyForMerge === true && mergeGateEligibility(rs).eligible;
+  });
   const memberships = await gatherMergeEligibility(readyStatuses.map(([issueId]) => issueId));
   const candidates: Array<{ issueId: string; title: string; pr?: number }> = [];
 
   for (const [issueId, rs] of readyStatuses) {
-    // Check if this issue belongs to this project
-    const issueProject = resolveProjectFromIssueSync(issueId);
-    if (!issueProject || issueProject.projectPath !== project.path) continue;
-
     const membership = memberships.get(issueId.toUpperCase());
     if (!membership || !isMergeEligible(membership)) continue;
 

--- a/src/lib/overdeck/infra.ts
+++ b/src/lib/overdeck/infra.ts
@@ -43,6 +43,7 @@ export const OVERDECK_SCHEMA_TOP_UP_EXPECTATIONS: SchemaTopUpExpectations = {
     { table: 'review_status', column: 'release_notes' },
     { table: 'review_status', column: 'uat_status' },
     { table: 'review_status', column: 'uat_notes' },
+    { table: 'review_status', column: 'retired_at' },
     { table: 'review_status', column: 'inspect_owner_session' },
     { table: 'review_status', column: 'strike_ready_head' },
     { table: 'review_status', column: 'strike_ready_at' },
@@ -162,6 +163,7 @@ function ensureRuntimeIndexesSync(db: SqliteDatabase): void {
   runSchemaTopUp(db, 'ALTER TABLE `review_status` ADD COLUMN `release_notes` text');
   runSchemaTopUp(db, 'ALTER TABLE `review_status` ADD COLUMN `uat_status` text');
   runSchemaTopUp(db, 'ALTER TABLE `review_status` ADD COLUMN `uat_notes` text');
+  runSchemaTopUp(db, 'ALTER TABLE `review_status` ADD COLUMN `retired_at` integer');
   runSchemaTopUp(db, 'ALTER TABLE `review_status` ADD COLUMN `inspect_owner_session` text');
   runSchemaTopUp(db, 'ALTER TABLE `review_status` ADD COLUMN `strike_ready_head` text');
   runSchemaTopUp(db, 'ALTER TABLE `review_status` ADD COLUMN `strike_ready_at` integer');

--- a/src/lib/overdeck/review-status-sync.ts
+++ b/src/lib/overdeck/review-status-sync.ts
@@ -59,6 +59,7 @@ interface DbRow {
   release_notes: string | null;
   updated_at: number;
   ready_for_merge: number;
+  retired_at: number | null;
   auto_requeue_count: number | null;
   merge_retry_count: number | null;
   pr_url: string | null;
@@ -116,6 +117,7 @@ function rowToReviewStatus(row: DbRow, history: StatusHistoryEntry[]): ReviewSta
     releaseNotes: row.release_notes ?? undefined,
     updatedAt: msToIso(row.updated_at) ?? new Date(0).toISOString(),
     readyForMerge: row.ready_for_merge === 1,
+    retiredAt: msToIso(row.retired_at),
     autoRequeueCount: row.auto_requeue_count ?? undefined,
     mergeRetryCount: row.merge_retry_count ?? undefined,
     prUrl: row.pr_url ?? undefined,
@@ -213,9 +215,9 @@ export function upsertReviewStatusSync(status: ReviewStatus): void {
         strike_ready_head, strike_ready_at, strike_landing_state,
         strike_recovery_count, strike_transport_retry_count,
         strike_next_attempt_at, strike_landing_attempts,
-        review_cycle_history
+        review_cycle_history, retired_at
       ) VALUES (
-        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
       )
       ON CONFLICT(issue_id) DO UPDATE SET
         review_status = excluded.review_status,
@@ -268,7 +270,8 @@ export function upsertReviewStatusSync(status: ReviewStatus): void {
         strike_transport_retry_count = excluded.strike_transport_retry_count,
         strike_next_attempt_at = excluded.strike_next_attempt_at,
         strike_landing_attempts = excluded.strike_landing_attempts,
-        review_cycle_history = excluded.review_cycle_history
+        review_cycle_history = excluded.review_cycle_history,
+        retired_at = excluded.retired_at
     `).run(
       s.issueId,
       s.reviewStatus,
@@ -322,6 +325,7 @@ export function upsertReviewStatusSync(status: ReviewStatus): void {
       isoToMs(s.strikeNextAttemptAt),
       s.strikeLandingAttempts ? JSON.stringify(s.strikeLandingAttempts) : null,
       s.reviewCycleHistory ? JSON.stringify(s.reviewCycleHistory) : null,
+      isoToMs(s.retiredAt),
     );
 
     if (s.history && s.history.length > 0) {

--- a/src/lib/overdeck/review-status-sync.ts
+++ b/src/lib/overdeck/review-status-sync.ts
@@ -554,10 +554,11 @@ export function getMergeBlockerReconcileCandidatesSync(): MergeBlockerReconcileC
   const rows = db.prepare(`
     SELECT issue_id, pr_url, blocker_reasons, ready_for_merge
     FROM review_status
-    WHERE ready_for_merge = 1
+    WHERE retired_at IS NULL AND (
+      ready_for_merge = 1
       OR blocker_reasons LIKE '%merge_conflict%'
       OR blocker_reasons LIKE '%not_mergeable%'
-      OR blocker_reasons LIKE '%failing_checks%'
+      OR blocker_reasons LIKE '%failing_checks%')
   `).all() as Array<{
     issue_id: string;
     pr_url: string | null;

--- a/src/lib/review-status-types.ts
+++ b/src/lib/review-status-types.ts
@@ -35,6 +35,8 @@ export interface ReviewStatus extends StrikeLandingStatus, InspectionStatusField
   releaseNotes?: string;
   updatedAt: string;
   readyForMerge: boolean;
+  /** Terminal marker for a closed/stale PR record; cleared only by fresh work or a new PR. */
+  retiredAt?: string;
   autoMerge?: boolean;
   autoRequeueCount?: number;
   mergeRetryCount?: number;

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -54,9 +54,10 @@ export interface MergeGateEligibility {
  * verification not failed, not already merged.
  */
 export function mergeGateEligibility(
-  status: Pick<ReviewStatus, 'reviewStatus' | 'testStatus' | 'verificationStatus' | 'mergeStatus'> | null,
+  status: Pick<ReviewStatus, 'reviewStatus' | 'testStatus' | 'verificationStatus' | 'mergeStatus' | 'retiredAt'> | null,
 ): MergeGateEligibility {
   if (!status) return { eligible: false, reason: 'no review record' };
+  if (status.retiredAt) return { eligible: false, reason: 'retired' };
   if (status.reviewStatus !== 'passed' && status.reviewStatus !== 'skipped') {
     return { eligible: false, reason: `review is ${status.reviewStatus}` };
   }
@@ -124,7 +125,7 @@ export function loadReadyForMergeFlags(issueIds: string[]): Map<string, boolean>
         merged.issueId = issueId;
         merged.updatedAt = journal.updatedAt;
         const hasBlockers = (merged.blockerReasons?.length ?? 0) > 0;
-        merged.readyForMerge = hasBlockers ? false : reviewGatesPassedSync(merged);
+        merged.readyForMerge = merged.retiredAt || hasBlockers ? false : reviewGatesPassedSync(merged);
         status = normalizeReviewStatusSync(merged);
       }
     }
@@ -241,7 +242,11 @@ export function setReviewStatusSync(
     delete update.testNotes;
   }
 
+  const freshPrIdentity =
+    (update.prNumber !== undefined && update.prNumber !== status.prNumber)
+    || (update.prUrl !== undefined && update.prUrl !== status.prUrl);
   const merged = settleMergedVerification({ ...status, ...update });
+  if (freshPrIdentity) merged.retiredAt = undefined;
 
   // Terminal verdicts consume the request that spawned this review. Preserve a newer request
   // because it represents an explicit re-review requested while the current review was running.
@@ -289,22 +294,19 @@ export function setReviewStatusSync(
   // Explicit caller intent still wins (the merge flow sets readyForMerge=false when a
   // merge starts; mergeStatus then leaves pending/queued so the derive agrees).
   // PAN-905/PAN-3365: merge blockers and failed required UAT override explicit readiness.
-  const hasBlockers = (merged.blockerReasons?.length ?? 0) > 0 || merged.uatStatus === 'failed';
+  const hasBlockers = Boolean(merged.retiredAt) || (merged.blockerReasons?.length ?? 0) > 0 || merged.uatStatus === 'failed';
   const readyForMerge = hasBlockers
     ? false
     : (update.readyForMerge !== undefined
         ? update.readyForMerge
         : reviewGatesPassedSync(merged));
 
-  // Create two versions of the history (PAN-3253):
-  // 1. Raw history (unbounded, untrun notes) for database write
-  // 2. Bounded history (last 20, truncated notes) for the returned event payload
+  // Keep raw history for storage and a bounded copy for the event payload (PAN-3253).
   const boundedHistory = rawHistory.slice(-REVIEW_STATUS_HISTORY_LIMIT).map((entry) => ({
     ...entry,
     notes: entry.notes ? truncateReviewStatusNote(entry.notes) : undefined,
   }));
 
-  // Write raw history to the database (for archival), but return bounded history in the status
   const dbStatus = normalizeReviewStatusSync({
     ...merged,
     issueId,
@@ -773,6 +775,7 @@ export function resetPipelineVerdictsForWorkStartSync(issueId: string, options: 
     lastVerifiedCommit: undefined,
     reviewRequestedAt: undefined, reviewSpawnedAt: undefined,
     conflictResolutionDispatchedAt: undefined, blockerReasons: undefined,
+    retiredAt: undefined,
   });
 }
 
@@ -905,6 +908,7 @@ export async function fixStuckReadyForMerge(
   for (const s of stuck) {
     const membership = memberships.get(s.issueId.toUpperCase());
     if (!membership || !mergeEligibility.isMergeEligible(membership)) {
+      if (membership) setReviewStatusSync(s.issueId, { readyForMerge: false, retiredAt: new Date().toISOString() });
       console.log(`[review-status] skipping ${s.issueId} — pipeline membership is ${membership?.bucket ?? 'unavailable'}, not merge-eligible`);
       continue;
     }

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -277,11 +277,9 @@ export function setReviewStatusSync(
   if (update.releaseStatus && update.releaseStatus !== status.releaseStatus) {
     rawHistory.push({ type: 'release', status: update.releaseStatus, timestamp: now, ...(update.releaseNotes ? { notes: update.releaseNotes } : {}) });
   }
-  // The history array in merged/updated will be bounded at hydration time during the
-  // upsertReviewStatusSync call, so this raw history may grow temporarily.
-  // The read-back via getReviewStatusFromDbSync will apply the bounds.
+  // Hydration bounds raw history before it reaches event payloads.
 
-  // PAN-1650: readyForMerge is EVENT-DRIVEN — derived from the gate state on every
+  // readyForMerge is event-driven and derived from gate state on every
   // write, so it flips the instant review+test+verification pass instead of waiting
   // for a deacon patrol or a startup `fixStuckReadyForMerge` reconcile (those become
   // redundant safety nets). This supersedes the PAN-1048 explicit-only model.
@@ -301,7 +299,6 @@ export function setReviewStatusSync(
         ? update.readyForMerge
         : reviewGatesPassedSync(merged));
 
-  // Keep raw history for storage and a bounded copy for the event payload (PAN-3253).
   const boundedHistory = rawHistory.slice(-REVIEW_STATUS_HISTORY_LIMIT).map((entry) => ({
     ...entry,
     notes: entry.notes ? truncateReviewStatusNote(entry.notes) : undefined,
@@ -312,7 +309,7 @@ export function setReviewStatusSync(
     issueId,
     updatedAt: now,
     readyForMerge,
-    history: rawHistory,  // Write raw (unbounded, untrun) history to the database
+    history: rawHistory,
   });
 
   const updated: ReviewStatus = normalizeReviewStatusSync({

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -890,6 +890,7 @@ export async function fixStuckReadyForMerge(
 ): Promise<void> {
   const statuses = loadReviewStatuses();
   const stuck = Object.values(statuses).filter(s =>
+    !s.retiredAt &&
     s.readyForMerge === false &&
     s.reviewStatus === 'passed' &&
     (s.testStatus === 'passed' || s.testStatus === 'skipped') &&

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -321,7 +321,7 @@ export function setReviewStatusSync(
   });
 
   // Report commit statuses to GitHub when readyForMerge transitions to true (PAN-536)
-  if (readyForMerge && !status.readyForMerge && updated.prUrl) {
+  if (readyForMerge && !status.readyForMerge && !updated.retiredAt && updated.prUrl) {
     (async () => {
       try {
         const { isGitHubAppConfigured, reportCommitStatus } = await import('./github-app.js');

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -882,17 +882,8 @@ export function clearStuckMergeStatuses(): void {
 }
 
 /**
- * On server startup, fix any issues where review+test both passed and
- * verificationStatus is not 'failed', but readyForMerge is stuck at false.
- *
- * This happens when:
- * 1. A merge attempt was made (merging → verifying)
- * 2. The server restarted while verifying — clearStuckMergeStatuses reset mergeStatus to 'pending'
- * 3. At restart time, verificationStatus was 'pending' (reset by the request-review cycle)
- * 4. The old verificationSatisfied check blocked readyForMerge because of 'pending' status
- *
- * With verificationSatisfied now only blocking on 'failed', these issues should be
- * re-evaluated and readyForMerge restored so they reappear on the Awaiting Merge page.
+ * Restore merge eligibility after a restart only when every gate passes and
+ * canonical pipeline membership confirms that the issue still has an open PR.
  */
 export async function fixStuckReadyForMerge(
   gatherEligibility?: typeof import('./cloister/merge-eligibility.js').gatherMergeEligibility,
@@ -903,9 +894,7 @@ export async function fixStuckReadyForMerge(
     s.reviewStatus === 'passed' &&
     (s.testStatus === 'passed' || s.testStatus === 'skipped') &&
     verificationSatisfied(s) &&
-    // Only fix 'pending'/'queued' merge states — not 'failed' ones.
-    // 'failed' means the merge actually attempted and broke; those need human review,
-    // not automatic restoration. 'merged' is done. Only pending/queued are stuck-but-valid.
+    // Failed and merged attempts are terminal; only pending/queued rows are repairable.
     (s.mergeStatus === 'pending' || s.mergeStatus === 'queued' || s.mergeStatus === undefined || s.mergeStatus === null) &&
     (s.uatStatus === undefined || s.uatStatus === 'passed')
   );

--- a/src/lib/review-status.ts
+++ b/src/lib/review-status.ts
@@ -894,7 +894,9 @@ export function clearStuckMergeStatuses(): void {
  * With verificationSatisfied now only blocking on 'failed', these issues should be
  * re-evaluated and readyForMerge restored so they reappear on the Awaiting Merge page.
  */
-export function fixStuckReadyForMerge(): void {
+export async function fixStuckReadyForMerge(
+  gatherEligibility?: typeof import('./cloister/merge-eligibility.js').gatherMergeEligibility,
+): Promise<void> {
   const statuses = loadReviewStatuses();
   const stuck = Object.values(statuses).filter(s =>
     s.readyForMerge === false &&
@@ -908,8 +910,15 @@ export function fixStuckReadyForMerge(): void {
     (s.uatStatus === undefined || s.uatStatus === 'passed')
   );
   if (stuck.length === 0) return;
+  const mergeEligibility = await import('./cloister/merge-eligibility.js');
+  const memberships = await (gatherEligibility ?? mergeEligibility.gatherMergeEligibility)(stuck.map((status) => status.issueId));
   console.log(`[review-status] Restoring readyForMerge for ${stuck.length} issue(s) with passed review+test`);
   for (const s of stuck) {
+    const membership = memberships.get(s.issueId.toUpperCase());
+    if (!membership || !mergeEligibility.isMergeEligible(membership)) {
+      console.log(`[review-status] skipping ${s.issueId} — pipeline membership is ${membership?.bucket ?? 'unavailable'}, not merge-eligible`);
+      continue;
+    }
     console.log(`[review-status] Restoring readyForMerge=true for ${s.issueId} (verif=${s.verificationStatus}, merge=${s.mergeStatus})`);
     setReviewStatusSync(s.issueId, { readyForMerge: true });
   }

--- a/src/lib/runtimes/__tests__/registry-dispatch.test.ts
+++ b/src/lib/runtimes/__tests__/registry-dispatch.test.ts
@@ -36,6 +36,7 @@ import {
   getGlobalRegistry,
   getHarnessBehavior,
 } from '../index.js'
+import { closeOverdeckDatabaseSync } from '../../overdeck/infra.js'
 import type { AgentRuntimeSync, HarnessBehavior } from '../types.js'
 
 function stubRuntime(name: 'claude-code' | 'ohmypi' | 'codex' | 'acp' | 'kimi-code'): AgentRuntimeSync {
@@ -88,6 +89,8 @@ describe('RuntimeRegistry.getRuntimeForAgent dispatches by state.harness (PAN-63
   let savedRegistry: ReturnType<typeof getGlobalRegistry> | null = null
 
   beforeEach(() => {
+    closeOverdeckDatabaseSync()
+    rmSync(TEST_OVERDECK_HOME, { recursive: true, force: true })
     savedRegistry = getGlobalRegistry()
     const fresh = new RuntimeRegistry()
     fresh.register(stubRuntime('claude-code'))
@@ -258,7 +261,7 @@ describe('getHarnessBehavior', () => {
 })
 
 afterEach(() => {
-  // Per-test cleanup so state.json fixtures don't bleed between cases.
-  rmSync(TEST_AGENTS_DIR, { recursive: true, force: true })
-  void TEST_OVERDECK_HOME // referenced for clarity
+  // Per-test cleanup so state.json and overdeck.db fixtures don't bleed.
+  closeOverdeckDatabaseSync()
+  rmSync(TEST_OVERDECK_HOME, { recursive: true, force: true })
 })

--- a/src/lib/webhook-handlers.ts
+++ b/src/lib/webhook-handlers.ts
@@ -502,7 +502,7 @@ export async function refreshMergeStateFromGitHub(issueId: string, repo: string,
 
   // For synchronize/opened/reopened the head SHA may have changed — skip SHA
   // validation so the handler can refresh prHeadSha and recompute blockers.
-  const headMayHaveMoved = ['synchronize', 'opened', 'reopened'].includes(payload.action ?? '');
+  const headMayHaveMoved = ['synchronize', 'opened', 'reopened', 'closed'].includes(payload.action ?? '');
   const status = await loadAndValidateStatus(issueId, repo, pr.number, headMayHaveMoved ? undefined : pr.head.sha);
   if (!status) return;
 

--- a/src/lib/webhook-handlers.ts
+++ b/src/lib/webhook-handlers.ts
@@ -231,8 +231,6 @@ function scheduleMergeStateReconciliation(issueId: string, repo: string, prNumbe
 
 export async function refreshMergeStateFromGitHub(issueId: string, repo: string, prNumber: number): Promise<void> {
   try {
-    const status = await Effect.runPromise(getReviewStatus(issueId));
-    if (!status || status.retiredAt) return;
     // Resolve PR merge state. Prefer the GitHub App REST path (installation
     // token, separate rate-limit budget, no GraphQL) when configured; fall back
     // to `gh pr view` (GraphQL) only when the App is not set up. Previously this
@@ -242,13 +240,19 @@ export async function refreshMergeStateFromGitHub(issueId: string, repo: string,
     const [owner, repoName] = repo.split('/');
     if (!owner || !repoName) return;
 
+    const { isGitHubAppConfigured, getPullRequestState } = await import('./github-app.js');
+    const githubAppConfigured = isGitHubAppConfigured();
+    if (!githubAppConfigured && isInGraphQLCooldown()) return;
+
+    const status = await Effect.runPromise(getReviewStatus(issueId));
+    if (!status || status.retiredAt) return;
+
     let mergeable: string;
     let mergeState: string;
     let isDraft: boolean;
     let checksFailed: boolean;
 
-    const { isGitHubAppConfigured, getPullRequestState } = await import('./github-app.js');
-    if (isGitHubAppConfigured()) {
+    if (githubAppConfigured) {
       // App REST path — installation token, separate rate-limit budget, no GraphQL.
       const prState = await Effect.runPromise(getPullRequestState(owner, repoName, prNumber));
       mergeable = prState.mergeable === null ? 'UNKNOWN' : prState.mergeable ? 'MERGEABLE' : 'CONFLICTING';
@@ -257,7 +261,6 @@ export async function refreshMergeStateFromGitHub(issueId: string, repo: string,
       checksFailed = prState.checksFailed;
     } else {
       // gh CLI fallback (GraphQL) — only when the App is not configured.
-      if (isInGraphQLCooldown()) return;
       const { execFile } = await import('child_process');
       const { promisify } = await import('util');
       const execFileAsync = promisify(execFile);

--- a/src/lib/webhook-handlers.ts
+++ b/src/lib/webhook-handlers.ts
@@ -231,6 +231,8 @@ function scheduleMergeStateReconciliation(issueId: string, repo: string, prNumbe
 
 export async function refreshMergeStateFromGitHub(issueId: string, repo: string, prNumber: number): Promise<void> {
   try {
+    const status = await Effect.runPromise(getReviewStatus(issueId));
+    if (!status || status.retiredAt) return;
     // Resolve PR merge state. Prefer the GitHub App REST path (installation
     // token, separate rate-limit budget, no GraphQL) when configured; fall back
     // to `gh pr view` (GraphQL) only when the App is not set up. Previously this
@@ -294,9 +296,6 @@ export async function refreshMergeStateFromGitHub(issueId: string, repo: string,
         && FAILING_CHECK_CONCLUSIONS.has((check.conclusion || check.state || '').toUpperCase()),
       );
     }
-
-    const status = await Effect.runPromise(getReviewStatus(issueId));
-    if (!status) return;
 
     const isConflicting = mergeable === 'CONFLICTING' || mergeState === 'DIRTY';
 

--- a/src/lib/webhook-handlers.ts
+++ b/src/lib/webhook-handlers.ts
@@ -510,6 +510,11 @@ export async function refreshMergeStateFromGitHub(issueId: string, repo: string,
   const update: ReviewStatusUpdate = {};
   let blockers = [...(status.blockerReasons ?? [])];
 
+  if (payload.action === 'closed' && pr.merged === false) {
+    update.readyForMerge = false;
+    update.retiredAt = new Date().toISOString();
+  }
+
   // Populate missing PR identity and keep head SHA in sync on synchronize
   if (!status.prUrl) update.prUrl = pr.html_url ?? `https://github.com/${repo}/pull/${pr.number}`;
   if (!status.prNumber) update.prNumber = pr.number;

--- a/tests/unit/dashboard/server/services/review-status-reconcile-service.test.ts
+++ b/tests/unit/dashboard/server/services/review-status-reconcile-service.test.ts
@@ -108,6 +108,37 @@ describe('review status reconcile service', () => {
     );
   });
 
+  it('heals one unchanged divergence, warns once, then heals after canonical advances', async () => {
+    mockQueryLatestPerIssue.mockReturnValue([statusEvent('2026-07-22T20:00:00.000Z')]);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    startReviewStatusReconcileService();
+    await vi.advanceTimersByTimeAsync(3 * 60_000);
+    expect(mockEmitReviewStatusChanged).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledWith(
+      `[review-status-reconcile] NOT CONVERGING for ${canonical.issueId}: ` +
+      `canonical=${canonical.updatedAt} event=2026-07-22T20:00:00.000Z`,
+    );
+
+    const advanced = { ...canonical, updatedAt: '2026-07-22T20:02:00.000Z' };
+    mockGetReviewStatusSync.mockReturnValue(advanced);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockEmitReviewStatusChanged).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips retired canonical records without emitting or warning', async () => {
+    mockGetReviewStatusSync.mockReturnValue({ ...canonical, retiredAt: '2026-08-16T00:00:00Z' });
+    mockQueryLatestPerIssue.mockReturnValue([statusEvent('2026-07-22T20:00:00.000Z')]);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    startReviewStatusReconcileService();
+    await vi.advanceTimersByTimeAsync(2 * 60_000);
+
+    expect(mockEmitReviewStatusChanged).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it('does not emit across several ticks when persisted JSON matches canonical status', async () => {
     const canonicalWithUndefined = { ...canonical, mergeNotes: undefined };
     const persisted = JSON.parse(JSON.stringify({

--- a/tests/unit/dashboard/server/services/review-status-reconcile-service.test.ts
+++ b/tests/unit/dashboard/server/services/review-status-reconcile-service.test.ts
@@ -139,6 +139,20 @@ describe('review status reconcile service', () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it('forgets reconciliation tracking when an issue retires', async () => {
+    mockQueryLatestPerIssue.mockReturnValue([statusEvent('2026-07-22T20:00:00.000Z')]);
+    startReviewStatusReconcileService();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockEmitReviewStatusChanged).toHaveBeenCalledOnce();
+
+    mockGetReviewStatusSync.mockReturnValue({ ...canonical, retiredAt: '2026-08-16T00:00:00Z' });
+    await vi.advanceTimersByTimeAsync(60_000);
+    mockGetReviewStatusSync.mockReturnValue(canonical);
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(mockEmitReviewStatusChanged).toHaveBeenCalledTimes(2);
+  });
+
   it('does not emit across several ticks when persisted JSON matches canonical status', async () => {
     const canonicalWithUndefined = { ...canonical, mergeNotes: undefined };
     const persisted = JSON.parse(JSON.stringify({

--- a/tests/unit/lib/cloister/deacon-stuck-readyformerge.test.ts
+++ b/tests/unit/lib/cloister/deacon-stuck-readyformerge.test.ts
@@ -19,6 +19,10 @@ vi.mock('../../../../src/lib/activity-logger.js', () => ({
   emitActivityTts: vi.fn(),
   emitActivityTtsSync: vi.fn(),
 }));
+vi.mock('../../../../src/lib/cloister/merge-eligibility.js', () => ({
+  gatherMergeEligibility: vi.fn(async (issueIds: string[]) => new Map(issueIds.map((issueId) => [issueId, { bucket: 'in_flight' }]))),
+  isMergeEligible: vi.fn((membership: { bucket: string }) => membership.bucket === 'in_flight'),
+}));
 
 beforeEach(() => {
   odb = setupOverdeckTestDb();
@@ -39,7 +43,7 @@ const seed = (cols: Record<string, string | number>) => {
 };
 
 describe('reconcileStuckReadyForMerge (PAN-2198)', () => {
-  it('flips readyForMerge for the no-blocker stuck strand, and is idempotent', () => {
+  it('flips readyForMerge for the no-blocker stuck strand, and is idempotent', async () => {
     seed({
       issue_id: 'PAN-STUCK',
       review_status: 'passed',
@@ -50,16 +54,16 @@ describe('reconcileStuckReadyForMerge (PAN-2198)', () => {
       ready_for_merge: 0,
     });
 
-    const actions = reconcileStuckReadyForMerge();
+    const actions = await reconcileStuckReadyForMerge();
     expect(actions).toHaveLength(1);
     expect(actions[0]).toContain('PAN-STUCK');
     expect(loadReviewStatuses()['PAN-STUCK'].readyForMerge).toBe(true);
 
     // Second tick: already flipped → no action (steady state = zero writes)
-    expect(reconcileStuckReadyForMerge()).toHaveLength(0);
+    expect(await reconcileStuckReadyForMerge()).toHaveLength(0);
   });
 
-  it('leaves a blocker-strand issue untouched (owned by reconcileStaleMergeBlockers)', () => {
+  it('leaves a blocker-strand issue untouched (owned by reconcileStaleMergeBlockers)', async () => {
     seed({
       issue_id: 'PAN-BLOCKED',
       review_status: 'passed',
@@ -71,11 +75,11 @@ describe('reconcileStuckReadyForMerge (PAN-2198)', () => {
       ready_for_merge: 0,
     });
 
-    expect(reconcileStuckReadyForMerge()).toHaveLength(0);
+    expect(await reconcileStuckReadyForMerge()).toHaveLength(0);
     expect(loadReviewStatuses()['PAN-BLOCKED'].readyForMerge).toBeFalsy();
   });
 
-  it('leaves an issue whose gates have not passed untouched', () => {
+  it('leaves an issue whose gates have not passed untouched', async () => {
     seed({
       issue_id: 'PAN-REVIEWING',
       review_status: 'reviewing',
@@ -86,7 +90,7 @@ describe('reconcileStuckReadyForMerge (PAN-2198)', () => {
       ready_for_merge: 0,
     });
 
-    expect(reconcileStuckReadyForMerge()).toHaveLength(0);
+    expect(await reconcileStuckReadyForMerge()).toHaveLength(0);
     expect(loadReviewStatuses()['PAN-REVIEWING'].readyForMerge).toBeFalsy();
   });
 });

--- a/tests/unit/lib/cloister/merge-eligibility-gate.test.ts
+++ b/tests/unit/lib/cloister/merge-eligibility-gate.test.ts
@@ -102,6 +102,22 @@ describe('readyForMerge pipeline-membership gates', () => {
     expect(loadReviewStatuses()['PAN-3753'].readyForMerge).toBe(false);
   });
 
+  it('does not gather or write retired records during the boot sweep', async () => {
+    seed('PAN-3753');
+    odb.raw().prepare('UPDATE review_status SET retired_at = ? WHERE issue_id = ?')
+      .run(Date.parse('2026-08-16T06:00:00Z'), 'PAN-3753');
+    const gather = vi.fn(eligibility('in_flight'));
+
+    await fixStuckReadyForMerge(gather);
+
+    expect(gather).not.toHaveBeenCalled();
+    expect(loadReviewStatuses()['PAN-3753']).toMatchObject({
+      readyForMerge: false,
+      retiredAt: '2026-08-16T06:00:00.000Z',
+      updatedAt: '2026-08-16T00:00:00.000Z',
+    });
+  });
+
   it('does not gather project lenses when there are no candidates', async () => {
     const gather = vi.fn(async () => []);
     const memberships = await gatherMergeEligibility([], {

--- a/tests/unit/lib/cloister/merge-eligibility-gate.test.ts
+++ b/tests/unit/lib/cloister/merge-eligibility-gate.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupOverdeckTestDb, teardownOverdeckTestDb, type OverdeckTestDb } from '../../../helpers/overdeck-test-db.js';
+import type { PipelineBucket } from '@overdeck/contracts';
+import type { PipelineMembership } from '../../../../src/lib/pipeline-membership.js';
+
+const mocks = vi.hoisted(() => ({
+  resolveConflictGate: vi.fn(),
+}));
+
+vi.mock('../../../../src/lib/pipeline-notifier.js', () => ({
+  notifyPipeline: vi.fn(),
+  notifyPipelineSync: vi.fn(),
+}));
+vi.mock('../../../../src/lib/activity-logger.js', () => ({
+  emitActivityEntry: vi.fn(),
+  emitActivityEntrySync: vi.fn(),
+  emitActivityTts: vi.fn(),
+  emitActivityTtsSync: vi.fn(),
+}));
+vi.mock('../../../../src/lib/cloister/conflict-gate.js', () => ({
+  buildRealConflictGateDeps: vi.fn(() => ({})),
+  resolveConflictGate: mocks.resolveConflictGate,
+}));
+
+import {
+  gatherMergeEligibility,
+  isMergeEligible,
+} from '../../../../src/lib/cloister/merge-eligibility.js';
+import {
+  reconcileStaleMergeBlockers,
+  reconcileStuckReadyForMerge,
+} from '../../../../src/lib/cloister/deacon-merge.js';
+import {
+  fixStuckReadyForMerge,
+  loadReviewStatuses,
+  setReviewStatusSync,
+} from '../../../../src/lib/review-status.js';
+
+let odb: OverdeckTestDb;
+
+const membership = (issueId: string, bucket: PipelineBucket): PipelineMembership => ({
+  issueId,
+  bucket,
+  inPipeline: bucket !== 'clean_terminal',
+  reasons: [],
+  labelDrift: null,
+  lenses: { L1_openPr: bucket === 'in_flight', L2_unmergedBranch: false, L3_issueOpen: true, L4_phaseLabel: null },
+});
+
+const eligibility = (bucket: PipelineBucket) => async (issueIds: string[]) =>
+  new Map(issueIds.map((issueId) => [issueId.toUpperCase(), membership(issueId, bucket)]));
+
+const seed = (issueId: string, blockers: unknown[] = []) => {
+  odb.raw().prepare(`INSERT INTO review_status (
+    issue_id, review_status, test_status, verification_status, merge_status,
+    blocker_reasons, updated_at, ready_for_merge
+  ) VALUES (?, 'passed', 'passed', 'passed', 'pending', ?, '2026-08-16T00:00:00Z', 0)`)
+    .run(issueId, JSON.stringify(blockers));
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-16T12:00:00Z'));
+  odb = setupOverdeckTestDb();
+  mocks.resolveConflictGate.mockReset();
+});
+
+afterEach(() => {
+  teardownOverdeckTestDb(odb);
+  vi.useRealTimers();
+});
+
+describe('readyForMerge pipeline-membership gates', () => {
+  it('keeps a stale blocker for planned backlog membership', async () => {
+    seed('PAN-3753', [{ type: 'merge_conflict', detail: 'main moved' }]);
+
+    expect(await reconcileStaleMergeBlockers(eligibility('planned_backlog'), () => true, () => '/tmp/workspace')).toEqual([]);
+    expect(mocks.resolveConflictGate).not.toHaveBeenCalled();
+    expect(loadReviewStatuses()['PAN-3753']).toMatchObject({ readyForMerge: false });
+    expect(loadReviewStatuses()['PAN-3753'].blockerReasons).toHaveLength(1);
+  });
+
+  it('still clears a stale blocker for in-flight membership', async () => {
+    vi.setSystemTime(new Date('2026-08-16T12:03:00Z'));
+    seed('PAN-3753', [{ type: 'merge_conflict', detail: 'main moved' }]);
+    mocks.resolveConflictGate.mockImplementation(async (issueId: string) => {
+      setReviewStatusSync(issueId, { blockerReasons: [] });
+      return { clearedStaleBlocker: true };
+    });
+
+    expect(await reconcileStaleMergeBlockers(eligibility('in_flight'), () => true, () => '/tmp/workspace')).toHaveLength(1);
+    expect(mocks.resolveConflictGate).toHaveBeenCalledOnce();
+    expect(loadReviewStatuses()['PAN-3753']).toMatchObject({ readyForMerge: true, blockerReasons: [] });
+  });
+
+  it('does not restore stuck readyForMerge in either patrol or boot sweep for planned backlog', async () => {
+    seed('PAN-3753');
+
+    expect(await reconcileStuckReadyForMerge(eligibility('planned_backlog'))).toEqual([]);
+    await fixStuckReadyForMerge(eligibility('planned_backlog'));
+
+    expect(loadReviewStatuses()['PAN-3753'].readyForMerge).toBe(false);
+  });
+
+  it('does not gather project lenses when there are no candidates', async () => {
+    const gather = vi.fn(async () => []);
+    const memberships = await gatherMergeEligibility([], {
+      resolveProject: vi.fn(),
+      getProject: vi.fn(),
+      gather,
+    });
+
+    expect(memberships.size).toBe(0);
+    expect(gather).not.toHaveBeenCalled();
+  });
+
+  it('gathers once per represented project and only in-flight is merge-eligible', async () => {
+    const gather = vi.fn(async () => [{
+      issueId: 'PAN-1', issueOpen: true, hasOpenPr: true, hasMergedPr: false,
+      hasConventionBranch: true, branchUnmerged: true, hasMergedBranchWork: false,
+      phaseLabel: 'in-review', hasXbriefSpec: true, explicitlyReady: false,
+      hasTerminalCloseOut: false,
+    }]);
+    const memberships = await gatherMergeEligibility(['PAN-1', 'PAN-2'], {
+      resolveProject: vi.fn((issueId: string) => ({ projectKey: 'overdeck', projectName: 'Overdeck', projectPath: '/repo', linearTeam: issueId.split('-')[0] })),
+      getProject: vi.fn(() => ({ name: 'Overdeck', path: '/repo', issue_prefix: 'PAN' })),
+      gather,
+    });
+
+    expect(gather).toHaveBeenCalledOnce();
+    expect(isMergeEligible(memberships.get('PAN-1')!)).toBe(true);
+  });
+});

--- a/tests/unit/lib/cloister/merge-eligibility-gate.test.ts
+++ b/tests/unit/lib/cloister/merge-eligibility-gate.test.ts
@@ -76,7 +76,7 @@ describe('readyForMerge pipeline-membership gates', () => {
 
     expect(await reconcileStaleMergeBlockers(eligibility('planned_backlog'), () => true, () => '/tmp/workspace')).toEqual([]);
     expect(mocks.resolveConflictGate).not.toHaveBeenCalled();
-    expect(loadReviewStatuses()['PAN-3753']).toMatchObject({ readyForMerge: false });
+    expect(loadReviewStatuses()['PAN-3753']).toMatchObject({ readyForMerge: false, retiredAt: '2026-08-16T12:00:00.000Z' });
     expect(loadReviewStatuses()['PAN-3753'].blockerReasons).toHaveLength(1);
   });
 

--- a/tests/unit/lib/cloister/retired-records-skip.test.ts
+++ b/tests/unit/lib/cloister/retired-records-skip.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
+import { setupOverdeckTestDb, teardownOverdeckTestDb, type OverdeckTestDb } from '../../../helpers/overdeck-test-db.js';
+
+const github = vi.hoisted(() => ({ getPullRequestState: vi.fn() }));
+vi.mock('../../../../src/lib/github-app.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../../../src/lib/github-app.js')>(),
+  isGitHubAppConfigured: vi.fn(() => true),
+  getPullRequestState: github.getPullRequestState,
+}));
+vi.mock('../../../../src/lib/pipeline-notifier.js', () => ({ notifyPipeline: vi.fn(), notifyPipelineSync: vi.fn() }));
+vi.mock('../../../../src/lib/activity-logger.js', () => ({
+  emitActivityEntry: vi.fn(), emitActivityEntrySync: vi.fn(), emitActivityTts: vi.fn(), emitActivityTtsSync: vi.fn(),
+}));
+
+import {
+  reconcileClosedPrReadyForMerge,
+  reconcileFalseMerged,
+  reconcileMergedButReviewing,
+  reconcileStaleMergeBlockers,
+  reconcileStaleMergeStatus,
+  reconcileStuckReadyForMerge,
+} from '../../../../src/lib/cloister/deacon-merge.js';
+import { getReviewStatusSync, setReviewStatusSync } from '../../../../src/lib/review-status.js';
+
+let odb: OverdeckTestDb;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  odb = setupOverdeckTestDb();
+  github.getPullRequestState.mockReturnValue(Effect.die('retired record reached GitHub'));
+  setReviewStatusSync('PAN-3753', {
+    reviewStatus: 'reviewing', testStatus: 'passed', verificationStatus: 'passed',
+    mergeStatus: 'merged', readyForMerge: false,
+    prUrl: 'https://github.com/eltmon/overdeck/pull/1679',
+    blockerReasons: [{ type: 'merge_conflict', summary: 'closed', detectedAt: '2026-08-16T00:00:00Z' }],
+  });
+  setReviewStatusSync('PAN-3753', { retiredAt: '2026-08-16T00:00:00Z', readyForMerge: false });
+});
+
+afterEach(() => {
+  teardownOverdeckTestDb(odb);
+  vi.useRealTimers();
+});
+
+describe('retired review records', () => {
+  it('produce no deacon actions or writes', async () => {
+    const before = getReviewStatusSync('PAN-3753');
+    const gather = vi.fn(async () => new Map());
+
+    expect(await reconcileStaleMergeStatus()).toEqual([]);
+    expect(await reconcileFalseMerged()).toEqual([]);
+    expect(await reconcileClosedPrReadyForMerge()).toEqual([]);
+    expect(await reconcileStaleMergeBlockers(gather)).toEqual([]);
+    expect(await reconcileStuckReadyForMerge(gather)).toEqual([]);
+    expect(await reconcileMergedButReviewing()).toEqual([]);
+
+    expect(github.getPullRequestState).not.toHaveBeenCalled();
+    expect(getReviewStatusSync('PAN-3753')).toEqual(before);
+  });
+});

--- a/tests/unit/lib/cloister/uat-generation-engine.test.ts
+++ b/tests/unit/lib/cloister/uat-generation-engine.test.ts
@@ -167,14 +167,15 @@ describe('assembleUatGeneration — happy path', () => {
     expect(store.rows.get(gen.name)!.status).toBe('ready');
   });
 
-  it('reuses the same deterministic daily branch on rebuild', async () => {
+  it('mints a unique daily branch and preserves the prior row on rebuild', async () => {
     const store = makeFakeStore();
     const git = makeFakeGit();
     const first = await assembleUatGeneration(input(), deps(git, store));
     const second = await assembleUatGeneration(input(), deps(git, store));
-    expect(second.name).toBe(first.name);
-    expect(git.calls.pushed).toEqual([first.name, first.name]);
-    expect(store.rows.get(first.name)!.status).toBe('ready');
+    expect(second.name).toBe(`${first.name}-2`);
+    expect(git.calls.pushed).toEqual([first.name, second.name]);
+    expect(store.rows.get(first.name)!.status).toBe('superseded');
+    expect(store.rows.get(second.name)!.status).toBe('ready');
   });
 });
 

--- a/tests/unit/lib/cloister/uat-reconciler.test.ts
+++ b/tests/unit/lib/cloister/uat-reconciler.test.ts
@@ -13,6 +13,9 @@ import {
 import type { ReadyFeature } from '../../../../src/lib/cloister/uat-generation-engine.js';
 import { needsReviewDispatch } from '../../../../src/lib/review-dispatch-decision.js';
 import type { UatGeneration, UatGenerationStatus } from '../../../../src/lib/database/uat-generations-db.js';
+import { makeUniqueUatCandidateName } from '../../../../src/lib/cloister/uat-candidate-name.js';
+import { generationFolderName } from '../../../../src/lib/cloister/uat-generation-engine.js';
+import { safeBranchName, safeGenerationWorktreePath } from '../../../../src/lib/cloister/uat-generation-deps.js';
 
 const MAIN = 'main-sha-1';
 const T0 = Date.parse('2026-06-10T12:00:00.000Z');
@@ -50,23 +53,27 @@ function makeDeps(projectRoot: string, options: {
   rows?: UatGeneration[];
   headShas?: Record<string, string>;
   assembleStatus?: UatGenerationStatus;
+  containedNames?: string[];
 } = {}): UatReconcilerDeps & {
   rows: Map<string, UatGeneration>;
   assembled: ReadyFeature[][];
   teardowns: string[];
   cleanups: number[];
+  logs: string[];
 } {
   const rows = new Map((options.rows ?? []).map((g) => [g.name, g]));
   const assembled: ReadyFeature[][] = [];
   const teardowns: string[] = [];
   const cleanups: number[] = [];
+  const logs: string[] = [];
   let assembleSeq = 0;
   return {
-    rows, assembled, teardowns, cleanups,
+    rows, assembled, teardowns, cleanups, logs,
     isEnabled: () => options.enabled ?? true,
     getReadySet: async () => options.readySet === undefined ? READY : options.readySet,
     getMainHeadSha: async () => MAIN,
     getBranchHeadSha: async (branch) => options.headShas?.[branch] ?? (branch === 'feature/pan-1' ? 'h1' : 'h2'),
+    isGenerationContainedInMain: async (generation) => options.containedNames?.includes(generation.name) ?? false,
     store: {
       insert: (g) => { rows.set(g.name, { ...g, createdAt: '', updatedAt: '' }); },
       update: (name, patch) => {
@@ -91,9 +98,39 @@ function makeDeps(projectRoot: string, options: {
     teardownStack: async (g) => { teardowns.push(g.name); },
     cleanup: async () => { cleanups.push(1); },
     now: () => T0,
-    log: () => {},
+    log: (message) => { logs.push(message); },
   };
 }
+
+describe('terminal promoted generations', () => {
+  it('stamps contained live branches promoted before stale invalidation', async () => {
+    const proj = freshProject();
+    const name = 'uat/pan-sable-0816';
+    const promoted = gen(proj, name, 'ready');
+    const deps = makeDeps(proj, { rows: [promoted], readySet: [], containedNames: [name] });
+
+    await reconcileUatGenerations(proj, deps);
+    expect(deps.rows.get(name)).toMatchObject({ status: 'promoted', members: promoted.members });
+    expect(deps.teardowns).toEqual([]);
+    expect(deps.logs).toContain(`[uat-reconciler] stamping ${name} promoted — branch is contained in main`);
+
+    await reconcileUatGenerations(proj, deps);
+    expect(deps.rows.get(name)?.status).toBe('promoted');
+  });
+
+  it('mints a same-day suffix without replacing the promoted name', () => {
+    const promoted = 'uat/pan-sable-0816';
+    const next = makeUniqueUatCandidateName({
+      label: 'pan', dateIso: '2026-08-16T12:00:00Z', codenames: ['sable'], pick: () => 0,
+    }, [promoted]);
+
+    expect(next).toBe('uat/pan-sable-0816-2');
+    expect(safeBranchName(next, 'uat')).toBe(next);
+    const folder = generationFolderName(next);
+    expect(safeGenerationWorktreePath('/project', `/project/workspaces/${folder}`)).toBe(`/project/workspaces/${folder}`);
+    expect(folder).toBe('uat-pan-sable-0816-2');
+  });
+});
 
 describe('gates', () => {
   it('no-ops when the merge train is disabled', async () => {

--- a/tests/unit/lib/flywheel-merge-order.test.ts
+++ b/tests/unit/lib/flywheel-merge-order.test.ts
@@ -287,9 +287,13 @@ describe('listEligibleCandidatesByProject eligibility gate (PAN-1759, moved by P
         return { eligible: true };
       },
     }));
+    vi.doMock('../../../src/lib/cloister/merge-eligibility.js', () => ({
+      gatherMergeEligibility: async (issueIds: string[]) => new Map(issueIds.map((issueId) => [issueId, { bucket: issueId === 'PAN-3' ? 'in_flight' : 'planned_backlog' }])),
+      isMergeEligible: (membership: { bucket: string }) => membership.bucket === 'in_flight',
+    }));
 
     const { listEligibleCandidatesByProject } = await import('../../../src/lib/flywheel-merge-order.js');
-    const candidates = listEligibleCandidatesByProject('/repo/overdeck');
+    const candidates = await listEligibleCandidatesByProject('/repo/overdeck');
 
     // PAN-3 alone survives: PAN-1 is mid-review, PAN-2 still testing, PAN-4 is
     // deacon-ignored, PAN-5 is not ready, PAN-6 is merged, and MIN-9 belongs to another project.

--- a/tests/unit/lib/flywheel-merge-order.test.ts
+++ b/tests/unit/lib/flywheel-merge-order.test.ts
@@ -287,8 +287,12 @@ describe('listEligibleCandidatesByProject eligibility gate (PAN-1759, moved by P
         return { eligible: true };
       },
     }));
+    const gatherMergeEligibility = vi.fn(async (issueIds: string[]) => {
+      if (issueIds.some((issueId) => issueId.startsWith('MIN-'))) throw new Error('unrelated project unavailable');
+      return new Map(issueIds.map((issueId) => [issueId, { bucket: issueId === 'PAN-3' ? 'in_flight' : 'planned_backlog' }]));
+    });
     vi.doMock('../../../src/lib/cloister/merge-eligibility.js', () => ({
-      gatherMergeEligibility: async (issueIds: string[]) => new Map(issueIds.map((issueId) => [issueId, { bucket: issueId === 'PAN-3' ? 'in_flight' : 'planned_backlog' }])),
+      gatherMergeEligibility,
       isMergeEligible: (membership: { bucket: string }) => membership.bucket === 'in_flight',
     }));
 
@@ -299,6 +303,7 @@ describe('listEligibleCandidatesByProject eligibility gate (PAN-1759, moved by P
     // deacon-ignored, PAN-5 is not ready, PAN-6 is merged, and MIN-9 belongs to another project.
     expect(candidates.map((candidate) => candidate.issueId)).toEqual(['PAN-3']);
     expect(candidates[0]).toMatchObject({ issueId: 'PAN-3', pr: 3 });
+    expect(gatherMergeEligibility).toHaveBeenCalledWith(['PAN-3']);
     vi.resetModules();
   });
 });

--- a/tests/unit/lib/overdeck/review-status-reconcile-candidates.test.ts
+++ b/tests/unit/lib/overdeck/review-status-reconcile-candidates.test.ts
@@ -29,4 +29,19 @@ describe('merge-blocker reconcile candidates', () => {
       expect.objectContaining({ issueId: 'PAN-2712', readyForMerge: false }),
     ]);
   });
+
+  it('excludes retired rows carrying merge blockers', () => {
+    odb.raw().prepare(`
+      INSERT INTO review_status
+        (issue_id, review_status, test_status, blocker_reasons, retired_at, updated_at, ready_for_merge)
+      VALUES (?, 'passed', 'passed', ?, ?, ?, 0)
+    `).run(
+      'PAN-3753',
+      JSON.stringify([{ type: 'not_mergeable', summary: 'closed PR' }]),
+      Date.now(),
+      Date.now(),
+    );
+
+    expect(getMergeBlockerReconcileCandidatesSync()).toEqual([]);
+  });
 });

--- a/tests/unit/lib/pan-dir/verdict-restore.test.ts
+++ b/tests/unit/lib/pan-dir/verdict-restore.test.ts
@@ -423,6 +423,7 @@ describe('restoreReviewStatusFromRecords', () => {
       'recovery_started_at',
       'inspect_started_at',
       'inspect_bead_id',
+      'retired_at',
     ]);
 
     const accountedFor = new Set([...primaryKey, ...durable, ...compatibilityOnly, ...derived, ...ephemeralDefaults]);

--- a/tests/unit/lib/review-status-retirement.test.ts
+++ b/tests/unit/lib/review-status-retirement.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Effect } from 'effect';
+import { setupOverdeckTestDb, teardownOverdeckTestDb, type OverdeckTestDb } from '../../helpers/overdeck-test-db.js';
+
+vi.mock('../../../src/lib/pipeline-notifier.js', () => ({
+  notifyPipeline: vi.fn(), notifyPipelineSync: vi.fn(),
+}));
+vi.mock('../../../src/lib/activity-logger.js', () => ({
+  emitActivityEntry: vi.fn(), emitActivityEntrySync: vi.fn(), emitActivityTts: vi.fn(), emitActivityTtsSync: vi.fn(),
+}));
+vi.mock('../../../src/lib/github-app.js', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../../src/lib/github-app.js')>(),
+  isGitHubAppConfigured: vi.fn(() => true),
+  getPullRequestState: vi.fn(() => Effect.succeed({ state: 'CLOSED', merged: false })),
+  reportCommitStatus: vi.fn(async () => undefined),
+}));
+
+import { reconcileClosedPrReadyForMerge } from '../../../src/lib/cloister/deacon-merge.js';
+import {
+  getReviewStatusSync,
+  loadReadyForMergeFlags,
+  mergeGateEligibility,
+  resetPipelineVerdictsForWorkStartSync,
+  setReviewStatusSync,
+} from '../../../src/lib/review-status.js';
+
+let odb: OverdeckTestDb;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-08-16T15:00:00Z'));
+  odb = setupOverdeckTestDb();
+});
+
+afterEach(() => {
+  teardownOverdeckTestDb(odb);
+  vi.useRealTimers();
+});
+
+function seed(issueId = 'PAN-3753') {
+  setReviewStatusSync(issueId, {
+    reviewStatus: 'passed',
+    testStatus: 'passed',
+    verificationStatus: 'passed',
+    mergeStatus: 'pending',
+    readyForMerge: true,
+    prNumber: 1679,
+    prUrl: 'https://github.com/eltmon/overdeck/pull/1679',
+  });
+}
+
+describe('review-status retirement', () => {
+  it('retires a closed-unmerged PR without replacing its merge status', async () => {
+    seed();
+
+    expect(await reconcileClosedPrReadyForMerge()).toHaveLength(1);
+    expect(getReviewStatusSync('PAN-3753')).toMatchObject({
+      readyForMerge: false,
+      mergeStatus: 'pending',
+      retiredAt: '2026-08-16T15:00:00.000Z',
+    });
+  });
+
+  it('persists retirement, rejects the record at the merge gate, and keeps it for same-PR echoes', () => {
+    seed('PAN-4000');
+    setReviewStatusSync('PAN-4000', { retiredAt: '2026-08-16T15:00:00.000Z', readyForMerge: false });
+
+    setReviewStatusSync('PAN-4000', { prNumber: 1679, prUrl: 'https://github.com/eltmon/overdeck/pull/1679' });
+    const retired = getReviewStatusSync('PAN-4000')!;
+    expect(retired.retiredAt).toBe('2026-08-16T15:00:00.000Z');
+    expect(mergeGateEligibility(retired)).toEqual({ eligible: false, reason: 'retired' });
+    expect(loadReadyForMergeFlags(['PAN-4000']).get('PAN-4000')).toBe(false);
+  });
+
+  it('clears retirement for a new PR identity or an explicit work restart', () => {
+    seed('PAN-4001');
+    setReviewStatusSync('PAN-4001', { retiredAt: '2026-08-16T15:00:00.000Z', readyForMerge: false });
+    setReviewStatusSync('PAN-4001', { prNumber: 1680, prUrl: 'https://github.com/eltmon/overdeck/pull/1680' });
+    expect(getReviewStatusSync('PAN-4001')?.retiredAt).toBeUndefined();
+
+    setReviewStatusSync('PAN-4001', { retiredAt: '2026-08-16T15:00:00.000Z', readyForMerge: false });
+    resetPipelineVerdictsForWorkStartSync('PAN-4001', { force: true });
+    expect(getReviewStatusSync('PAN-4001')?.retiredAt).toBeUndefined();
+  });
+});

--- a/tests/unit/lib/webhook-handlers.test.ts
+++ b/tests/unit/lib/webhook-handlers.test.ts
@@ -395,6 +395,24 @@ describe('handlePullRequest', () => {
     }));
   });
 
+  it('retires a closed PR when the stored head SHA is stale', async () => {
+    mockGetReviewStatus.mockReturnValue({ blockerReasons: [], prNumber: 1, prHeadSha: 'older-sha' });
+
+    await Effect.runPromise(handlePullRequest(makePayload({
+      action: 'closed',
+      pull_request: {
+        number: 1,
+        head: { ref: 'feature/pan-123', sha: 'final-sha' },
+        merged: false,
+      },
+    })));
+
+    expect(mockSetReviewStatus).toHaveBeenCalledWith('PAN-123', expect.objectContaining({
+      readyForMerge: false,
+      retiredAt: expect.any(String),
+    }));
+  });
+
   it.each(['opened', 'closed', 'reopened'])('enqueues membership refresh for %s PRs', async (action) => {
     await Effect.runPromise(handlePullRequest(makePayload({
       action,

--- a/tests/unit/lib/webhook-handlers.test.ts
+++ b/tests/unit/lib/webhook-handlers.test.ts
@@ -1126,6 +1126,16 @@ describe('refreshMergeStateFromGitHub (PAN-2265)', () => {
     ghPrViewStdout = '';
   });
 
+  it('does not query GitHub for a retired record', async () => {
+    mockGetReviewStatus.mockReturnValue({ retiredAt: '2026-08-16T00:00:00Z', blockerReasons: [] });
+
+    await refreshMergeStateFromGitHub('PAN-3753', 'test-owner/test-repo', 42);
+
+    expect(mockGetPullRequestState).not.toHaveBeenCalled();
+    expect(mockExecFile).not.toHaveBeenCalled();
+    expect(mockSetReviewStatus).not.toHaveBeenCalled();
+  });
+
   it('uses the App REST path (not gh) when the App is configured', async () => {
     mockGetReviewStatus.mockReturnValue({ blockerReasons: [] });
     mockGetPullRequestState.mockReturnValue(makeAppPrState({ mergeable: false, mergeableState: 'dirty' }));

--- a/tests/unit/lib/webhook-handlers.test.ts
+++ b/tests/unit/lib/webhook-handlers.test.ts
@@ -377,6 +377,24 @@ describe('handleCheckRun', () => {
 });
 
 describe('handlePullRequest', () => {
+  it('retires a review record when its PR closes without merging', async () => {
+    mockGetReviewStatus.mockReturnValue({ blockerReasons: [], prNumber: 1 });
+
+    await Effect.runPromise(handlePullRequest(makePayload({
+      action: 'closed',
+      pull_request: {
+        number: 1,
+        head: { ref: 'feature/pan-123' },
+        merged: false,
+      },
+    })));
+
+    expect(mockSetReviewStatus).toHaveBeenCalledWith('PAN-123', expect.objectContaining({
+      readyForMerge: false,
+      retiredAt: expect.any(String),
+    }));
+  });
+
   it.each(['opened', 'closed', 'reopened'])('enqueues membership refresh for %s PRs', async (action) => {
     await Effect.runPromise(handlePullRequest(makePayload({
       action,

--- a/tests/unit/scripts/create-overdeck-db.test.ts
+++ b/tests/unit/scripts/create-overdeck-db.test.ts
@@ -48,6 +48,8 @@ describe('createOverdeckDatabase', () => {
     try {
       const tables = tableNames(db);
       expect(tables).toHaveLength(OVERDECK_TABLE_COUNT);
+      const reviewStatusColumns = db.prepare('PRAGMA table_info(review_status)').all<{ name: string }>();
+      expect(reviewStatusColumns.map((column) => column.name)).toContain('retired_at');
 
       for (const tableName of tables) {
         const row = db.prepare(`SELECT COUNT(*) AS count FROM "${tableName}"`).get<{ count: number }>();


### PR DESCRIPTION
**Issue:** #3753

## Acceptance Criteria

- [ ] Gate every readyForMerge deriver through the pipeline-membership resolver
- [ ] Exclude non-merge-eligible issues from the merge-train projection
- [ ] Add the retiredAt terminal marker with set/unset triggers
- [ ] Make every review-status consumer skip retired records
- [ ] Make promoted UAT generations terminal and same-day names unique
- [ ] Converge the review-status heal loop after one heal per canonical updatedAt
- [ ] Validate membership in POST /api/merge-train/merge-next before merging
- [ ] Document review-status retirement, terminal generations, and the actionability rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Merge queues now include only actively in-flight issues and recheck eligibility before merging.
  - Closed, unmerged pull requests are retired while historical status is preserved.
  - UAT generations avoid naming collisions and are promoted only when branches are contained in `main`.

- **Bug Fixes**
  - Prevented stale or ineligible issues from being restored to merge-ready status.
  - Improved startup and reconciliation reliability.

- **Documentation**
  - Documented merge eligibility, review-status retirement, and terminal UAT behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->