### PR TITLE
feat(dashboard): show Codex subagent transcripts in conversations

### DIFF
--- a/docs/CONVERSATION-SUBAGENTS.md
+++ b/docs/CONVERSATION-SUBAGENTS.md
@@ -1,6 +1,6 @@
 # Conversation subagents
 
-Claude Code writes each subagent beside its parent conversation transcript. Overdeck reads these files to list subagents and show their full transcripts in the conversation panel. The dashboard never modifies the files.
+Claude Code and Codex expose subagents through the same conversation rail. Claude Code writes each subagent beside its parent conversation transcript. Overdeck reads these files to list subagents and show their full transcripts in the conversation panel. The dashboard never modifies the files.
 
 ## On-disk layout
 
@@ -68,3 +68,33 @@ Subagent transcript lookup accepts only ids that match:
 ```
 
 The resolver then builds the candidate with `path.resolve` and verifies that its parent directory is the resolved `subagents` directory. Invalid ids return `null`, and the REST route returns HTTP 400 before any transcript read. Discovery and transcript access use asynchronous filesystem APIs and remain read-only.
+
+## Codex child threads
+
+Codex stores children as separate `rollout-*.jsonl` files in the parent's
+`codex-home/sessions/YYYY/MM/DD/` tree. The first `session_meta` record supplies
+`payload.id` and `payload.source.subagent.thread_spawn.parent_thread_id`.
+`agent_path`, `agent_nickname`, and `agent_role` supply display labels when present.
+The resolver follows these parent IDs to discover descendants across date directories.
+It computes depth relative to the selected parent and excludes ordinary conversation forks.
+
+Codex uses the same list event, `agentId` subscription field, REST query, URL
+selection, and isolated transcript cache as Claude Code. The selected child passes
+through the Codex parser and existing full-snapshot file watcher. A two-second
+poll discovers new children and changes to their status even when the parent
+transcript does not change. Child streams do not emit their own subagent lists.
+
+The resolver reads and caches metadata separately from transcript content. It reads
+a bounded 128 KiB tail for status: the most recent `task_started` means running;
+`task_complete` or `turn_aborted` means done. A later task starts the running status
+again. Without a terminal event in that tail, it reports running.
+
+A parent `spawn_agent` work-log row joins to a child through its result's
+`agent_id` or `thread_id`, or through the collaboration tool's `task_name`, which
+matches the child's `agent_path`. That row offers **Open subagent transcript**.
+Children without a matching spawn row remain accessible through the rail.
+
+Selection accepts only safe IDs and requires membership in the parent's verified
+descendant tree. It never interprets an ID as a path, follows directory/file
+symlinks during discovery, or searches another Codex home. Missing or unrelated
+IDs cannot fall back to the parent transcript. All discovery and reads are asynchronous.

--- a/reference/architecture.mdx
+++ b/reference/architecture.mdx
@@ -54,9 +54,9 @@ Because the `projects.yaml` registry (see [Directory Structure](#directory-struc
 
 ### Conversation subagents
 
-When a Claude Code conversation starts subagents through the `Agent` tool, the conversation panel opens a **Subagents** rail on the right. Each row shows the subagent type, description, live status, and nesting depth. Select a row—or choose **Open subagent transcript** from its expanded tool row—to read the subagent's full transcript without leaving the parent conversation.
+When a Claude Code or Codex conversation starts subagents, the conversation panel shows an **Agents** rail on the right. Each row shows the subagent type, description, live status, and nesting depth. Select a row—or choose **Open subagent transcript** from its expanded tool row—to read the subagent's full transcript without leaving the parent conversation.
 
-The selected subagent is stored in the `?subagent=<id>` URL parameter, so a direct link reopens the same transcript. The rail stays hidden when a conversation has no subagents. Pi and Codex conversations are unchanged because they do not use Claude Code's subagent file layout.
+The selected subagent is stored in the `?subagent=<id>` URL parameter, so a direct link reopens the same transcript. The rail stays hidden when a conversation has no subagents. Codex children use the same interaction, including live updates and reopening completed transcripts. The rail includes nested children. Pi conversations do not currently expose subagents in this view.
 
 ## Directory Structure
 

--- a/src/dashboard/frontend/src/components/chat/messagesTimeline/messageRows.test.tsx
+++ b/src/dashboard/frontend/src/components/chat/messagesTimeline/messageRows.test.tsx
@@ -114,8 +114,8 @@ describe('subagent transcript action', () => {
     status: 'done',
   };
 
-  it('opens the matching subagent from an expanded Agent row without a raw JSON fallback', () => {
-    const agentEntry = { ...entry, label: 'Agent', toolTitle: 'Agent' };
+  it.each(['Agent', 'Task'])('opens the matching subagent from an expanded %s row', (tool) => {
+    const agentEntry = { ...entry, label: tool, toolTitle: tool };
     const onOpenSubagent = vi.fn();
     render(
       <WorkLogGroup
@@ -125,10 +125,23 @@ describe('subagent transcript action', () => {
       />,
     );
 
-    fireEvent.click(screen.getByText('Agent'));
+    fireEvent.click(screen.getByText(tool));
     expect(screen.getByText('Explore')).toBeInTheDocument();
     expect(screen.getByTestId('md')).toHaveTextContent('Find the relevant message path.');
     expect(screen.queryByText(/"subagent_type"/)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Open subagent transcript' }));
+    expect(onOpenSubagent).toHaveBeenCalledWith(entry.id);
+  });
+
+  it('opens a Codex child while preserving every spawn argument and the tool result', () => {
+    const toolInput = { task_name: 'reader', message: 'Inspect the parser', fork_turns: 'all', agent_type: 'explorer' };
+    const result = '{"task_name":"/root/reader"}';
+    const onOpenSubagent = vi.fn();
+    render(<WorkLogGroup entries={[{ ...entry, label: 'spawn_agent', toolTitle: 'spawn_agent', toolInput, result }]}
+      subagentByToolUseId={new Map([[entry.id, subagent]])} onOpenSubagent={onOpenSubagent} />);
+    fireEvent.click(screen.getByText('spawn_agent'));
+    expect(screen.getByText((_, element) => element?.tagName === 'CODE' && element.textContent === JSON.stringify(toolInput, null, 2))).toBeInTheDocument();
+    expect(screen.getByText(result)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Open subagent transcript' }));
     expect(onOpenSubagent).toHaveBeenCalledWith(entry.id);
   });

--- a/src/dashboard/frontend/src/components/chat/messagesTimeline/workLogRows.tsx
+++ b/src/dashboard/frontend/src/components/chat/messagesTimeline/workLogRows.tsx
@@ -288,9 +288,18 @@ function ToolUseExpanded({
   // Fallback: pretty-printed JSON. Replaces the previous behavior of stuffing
   // JSON.stringify(input) into a one-line `detail` string with no formatting.
   return (
-    <pre className={styles.workLogResult}>
-      <code>{JSON.stringify(input, null, 2)}</code>
-    </pre>
+    <div className={styles.workLogResult}>
+      {subagentByToolUseId?.has(entry.id) && onOpenSubagent && (
+        <button
+          type="button"
+          className="mb-2 text-xs font-medium text-primary transition-colors hover:text-primary/80"
+          onClick={() => onOpenSubagent(entry.id)}
+        >
+          Open subagent transcript
+        </button>
+      )}
+      <pre><code>{JSON.stringify(input, null, 2)}</code></pre>
+    </div>
   );
 }
 

--- a/src/dashboard/server/__tests__/ws-rpc-resolved-stream.test.ts
+++ b/src/dashboard/server/__tests__/ws-rpc-resolved-stream.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { Effect, Stream } from 'effect';
 
 // Stub the transcript resolvers so the dispatch can be asserted on the exact
@@ -6,12 +9,18 @@ import { Effect, Stream } from 'effect';
 const resolverMock = vi.hoisted(() => ({
   resolveAgentHarness: vi.fn(async () => 'claude-code'),
   resolvePiSessionPath: vi.fn(async () => null),
-  resolveCodexRolloutPath: vi.fn(async () => null),
+  resolveCodexRolloutPath: vi.fn(async (): Promise<string | null> => null),
   resolveAcpTranscriptPath: vi.fn(async () => null),
   resolveKimiWirePath: vi.fn(async () => null),
   readLauncherPinnedSessionId: vi.fn(async () => null),
 }));
 vi.mock('../routes/jsonl-resolver.js', () => resolverMock);
+vi.mock('../services/dashboard-db-task.js', () => ({
+  runDashboardDbJob: vi.fn(async (_operation: string, input: { sessionFile: string }) => {
+    const { parseCodexConversationMessages } = await import('../services/codex-conversation-parser.js');
+    return parseCodexConversationMessages(input.sessionFile);
+  }),
+}));
 
 import {
   streamHarnessFullParseSnapshots,
@@ -128,5 +137,42 @@ describe('streamResolvedFullParseSnapshots — unresolved transcript', () => {
     );
 
     expect(Array.from(first)).toEqual([{ kind: 'discovering' }]);
+  });
+});
+
+
+describe('Codex subagent stream dispatch', () => {
+  it('emits a parent list and streams only the selected child with no nested list', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'codex-subagent-stream-'));
+    const folder = join(dir, 'sessions', '2026', '09', '08');
+    await mkdir(folder, { recursive: true });
+    const parent = join(folder, 'rollout-parent.jsonl');
+    const child = join(folder, 'rollout-child.jsonl');
+    try {
+      for (const [file, id, source, message] of [
+        [parent, 'parent', 'cli', 'Parent'],
+        [child, 'child', { subagent: { thread_spawn: { parent_thread_id: 'parent' } } }, 'Child'],
+      ] as const) {
+        await writeFile(file, [
+          { type: 'session_meta', payload: { id, source } },
+          { type: 'event_msg', payload: { type: 'agent_message', message } },
+          { type: 'event_msg', payload: { type: 'task_complete' } },
+        ].map(e => JSON.stringify(e)).join('\n') + '\n');
+      }
+      resolverMock.resolveCodexRolloutPath.mockResolvedValue(parent);
+      const stream = streamHarnessFullParseSnapshots('conv-codex', 'codex', null, true)!;
+      const events = Array.from(await Effect.runPromise(stream.pipe(Stream.take(2), Stream.runCollect)));
+      expect(events[0]).toMatchObject({ kind: 'messages', messages: [{ text: 'Parent' }] });
+      expect(events[1]).toMatchObject({ kind: 'subagents', subagents: [{ agentId: 'child' }] });
+      const selected = streamHarnessFullParseSnapshots('conv-codex', 'codex', null, true, null, 'child')!;
+      const childEvents = Array.from(await Effect.runPromise(selected.pipe(Stream.take(1), Stream.runCollect)));
+      expect(childEvents).toEqual([expect.objectContaining({ kind: 'messages', messages: [expect.objectContaining({ text: 'Child' })] })]);
+      const invalid = streamHarnessFullParseSnapshots('conv-codex', 'codex', null, true, null, 'parent')!;
+      expect(Array.from(await Effect.runPromise(invalid.pipe(Stream.take(1), Stream.runCollect))))
+        .toEqual([{ kind: 'messages', messages: [], workLog: [], streaming: false, snapshot: true }]);
+    } finally {
+      resolverMock.resolveCodexRolloutPath.mockResolvedValue(null);
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/dashboard/server/services/codex-conversation-parser.ts
+++ b/src/dashboard/server/services/codex-conversation-parser.ts
@@ -66,6 +66,14 @@ interface CodexEntry {
   [k: string]: unknown;
 }
 
+function parseToolInput(args: string): Record<string, unknown> | undefined {
+  try {
+    const value: unknown = JSON.parse(args);
+    return value !== null && typeof value === 'object' && !Array.isArray(value)
+      ? value as Record<string, unknown> : undefined;
+  } catch { return undefined; }
+}
+
 /** Flatten a Codex tool output (usually a string) into display text. */
 function extractToolOutput(output: unknown): string {
   if (typeof output === 'string') return output.trim();
@@ -181,6 +189,7 @@ export async function parseCodexConversationMessages(sessionFile: string): Promi
           createdAt,
           label: command ? 'Shell' : name,
           tone: 'tool',
+          ...(name === 'spawn_agent' ? { toolInput: parseToolInput(args) } : {}),
           sequence,
           ...(command ? { command } : args ? { detail: args } : {}),
         };

--- a/src/dashboard/server/services/conversation/codex-subagents.ts
+++ b/src/dashboard/server/services/conversation/codex-subagents.ts
@@ -1,0 +1,153 @@
+/** Read-only Codex child-thread discovery, scoped to the parent's sessions tree. */
+import { createReadStream } from 'node:fs';
+import { open, readdir } from 'node:fs/promises';
+import { basename, dirname, join } from 'node:path';
+import { createInterface } from 'node:readline';
+import type { SubagentSummary, WorkLogEntry } from '@overdeck/contracts';
+
+type ObjectValue = Record<string, unknown>;
+function object(value: unknown): ObjectValue {
+  if (typeof value === 'string') {
+    try { return object(JSON.parse(value)); } catch { return {}; }
+  }
+  return value !== null && typeof value === 'object' && !Array.isArray(value) ? value as ObjectValue : {};
+}
+function text(value: unknown): string { return typeof value === 'string' ? value : ''; }
+
+interface ThreadMeta {
+  id: string;
+  parentId: string;
+  path: string;
+  name: string;
+  role: string;
+  file: string;
+}
+const metadata = new Map<string, ThreadMeta>();
+
+async function readMeta(file: string): Promise<ThreadMeta | null> {
+  const cached = metadata.get(file);
+  if (cached) return cached;
+  const input = createReadStream(file, { encoding: 'utf8' });
+  const lines = createInterface({ input, crlfDelay: Infinity });
+  try {
+    for await (const line of lines) {
+      const entry = object(line);
+      if (entry.type !== 'session_meta') return null;
+      const payload = object(entry.payload);
+      const spawn = object(object(object(payload.source).subagent).thread_spawn);
+      const id = text(payload.id);
+      if (!id) return null;
+      const meta = {
+        id, file,
+        // Only thread_spawn establishes ownership; ordinary conversation forks do not.
+        parentId: text(spawn.parent_thread_id),
+        path: text(spawn.agent_path ?? payload.agent_path),
+        name: text(spawn.agent_nickname ?? payload.agent_nickname),
+        role: text(spawn.agent_role ?? payload.agent_role),
+      };
+      if (metadata.size >= 512) metadata.delete(metadata.keys().next().value!);
+      metadata.set(file, meta);
+      return meta;
+    }
+    return null;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw error;
+  } finally {
+    lines.close();
+    input.destroy();
+  }
+}
+
+function sessionsRoot(file: string): string | null {
+  let dir = dirname(file);
+  while (dirname(dir) !== dir) {
+    if (basename(dir) === 'sessions') return dir;
+    dir = dirname(dir);
+  }
+  return null;
+}
+
+async function rollouts(dir: string): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    // Do not follow symlinks out of the parent's Codex home.
+    if (entry.isDirectory()) files.push(...await rollouts(path));
+    else if (entry.isFile() && /^rollout-.*\.jsonl$/.test(entry.name)) files.push(path);
+  }
+  return files.sort();
+}
+
+async function descendants(parentFile: string): Promise<Array<{ meta: ThreadMeta; depth: number }>> {
+  const root = sessionsRoot(parentFile);
+  if (!root) return [];
+  const parent = await readMeta(parentFile);
+  if (!parent) return [];
+  const metas: ThreadMeta[] = [];
+  for (const file of await rollouts(root)) {
+    const meta = await readMeta(file);
+    if (meta?.parentId) metas.push(meta);
+  }
+  const depths = new Map([[parent.id, 0]]);
+  const children: Array<{ meta: ThreadMeta; depth: number }> = [];
+  // Walk by verified parent IDs, including grandchildren, regardless of file order.
+  for (let i = 0; i <= children.length; i++) {
+    const parentId = i === 0 ? parent.id : children[i - 1].meta.id;
+    for (const meta of metas) {
+      if (meta.parentId !== parentId || depths.has(meta.id)) continue;
+      const depth = depths.get(parentId)! + 1;
+      depths.set(meta.id, depth);
+      children.push({ meta, depth });
+    }
+  }
+  return children;
+}
+
+async function threadStatus(file: string): Promise<SubagentSummary['status']> {
+  const handle = await open(file, 'r');
+  try {
+    const { size } = await handle.stat();
+    const start = Math.max(0, size - 128 * 1024);
+    const buffer = Buffer.alloc(size - start);
+    await handle.read(buffer, 0, buffer.length, start);
+    const lines = buffer.toString('utf8').split('\n');
+    if (start > 0) lines.shift();
+    for (const line of lines.reverse()) {
+      const entry = object(line);
+      if (entry.type !== 'event_msg') continue;
+      const payload = object(entry.payload);
+      if (payload.type === 'task_complete' || payload.type === 'turn_aborted') return 'done';
+      if (payload.type === 'task_started') return 'running';
+    }
+    return 'running';
+  } finally { await handle.close(); }
+}
+
+export async function listCodexSubagents(parentFile: string, workLog: readonly WorkLogEntry[] = []): Promise<SubagentSummary[]> {
+  const children = await descendants(parentFile);
+  const summaries: SubagentSummary[] = [];
+  for (const { meta, depth } of children) {
+    const call = depth === 1 ? workLog.find((entry) => {
+      if (entry.label !== 'spawn_agent') return false;
+      const output = object(entry.result);
+      return output.agent_id === meta.id || output.thread_id === meta.id
+        || (meta.path !== '' && output.task_name === meta.path);
+    }) : undefined;
+    const args = object(call?.toolInput ?? call?.detail);
+    summaries.push({
+      agentId: meta.id,
+      agentType: meta.role || meta.name || 'Codex',
+      description: text(args.task_name) || meta.path || meta.name || 'Subagent',
+      toolUseId: call?.id ?? meta.id,
+      spawnDepth: depth,
+      status: await threadStatus(meta.file),
+    });
+  }
+  return summaries;
+}
+
+export async function resolveCodexSubagentTranscript(parentFile: string, agentId: string): Promise<string | null> {
+  if (!/^[A-Za-z0-9_-]+$/.test(agentId)) return null;
+  return (await descendants(parentFile)).find(({ meta }) => meta.id === agentId)?.meta.file ?? null;
+}

--- a/src/dashboard/server/services/conversation/subagents.ts
+++ b/src/dashboard/server/services/conversation/subagents.ts
@@ -99,6 +99,7 @@ export async function startSubagentListPolling(
   sessionFile: string,
   pendingToolUseIds: () => ReadonlySet<string>,
   emit: (event: ConversationEvent) => void,
+  list?: () => Promise<SubagentSummary[]>,
 ): Promise<SubagentListPoller> {
   let stopped = false;
   let lastSerialized: string | null = null;
@@ -108,10 +109,11 @@ export async function startSubagentListPolling(
     refreshChain = refreshChain.then(async () => {
       if (stopped) return;
       const pending = pendingToolUseIds();
-      const subagents: SubagentSummary[] = (await listSubagentMetas(sessionFile)).map((meta) => ({
+      const subagents: SubagentSummary[] = list ? await list() : (await listSubagentMetas(sessionFile)).map((meta) => ({
         ...meta,
         status: pending.has(meta.toolUseId) ? 'running' : 'done',
       }));
+      if (stopped) return;
       const serialized = JSON.stringify(subagents);
       if (serialized === lastSerialized) return;
       lastSerialized = serialized;

--- a/src/dashboard/server/ws-rpc.ts
+++ b/src/dashboard/server/ws-rpc.ts
@@ -41,7 +41,8 @@ import { readFileAtPathEffect, writeFileAtPathEffect } from './services/file-at-
 import { resolveFilePathExistsEffect } from './services/resolve-file-path-exists.js';
 import { getHarnessBehavior } from '../../lib/runtimes/behavior.js';
 import { normalizeSessionsFeedFilter, toDiscoveredSessionSnapshot, toSessionsFeedRowSnapshot } from './services/sessions-feed-rpc.js';
-import { startSubagentListPolling, subagentTranscriptPath } from './services/conversation/subagents.js';
+import { listCodexSubagents, resolveCodexSubagentTranscript } from './services/conversation/codex-subagents.js';
+import { startSubagentListPolling, subagentTranscriptPath, type SubagentListPoller } from './services/conversation/subagents.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -113,10 +114,13 @@ export function streamResolvedFullParseSnapshots(
   // null ONLY when no transcript exists on disk (a resumed conversation already
   // has its file), so emitting an empty snapshot here never blanks real history.
   unresolvedMeansEmpty = false,
+  discoverSubagents = false,
 ): Stream.Stream<ConversationEvent, PanRpcError> {
   return Stream.callback<ConversationEvent, PanRpcError>((queue) =>
     Effect.acquireRelease(
       Effect.promise(async () => {
+        let subagentPoller: SubagentListPoller | null = null;
+        let latestWorkLog: ParseResult['workLog'] = [];
         let stopped = false;
         let resolving = false;
         let discoveryTimer: ReturnType<typeof setInterval> | null = null;
@@ -157,6 +161,8 @@ export function streamResolvedFullParseSnapshots(
           parsing = true;
           try {
             const result = await parse(sessionFile);
+            if (stopped) return;
+            latestWorkLog = result.workLog;
             if (result.messages.length > 0 && !hasContent) {
               // Real content arrived — lock onto this file and stop polling.
               hasContent = true;
@@ -175,6 +181,15 @@ export function streamResolvedFullParseSnapshots(
                   : undefined,
               contextUsage: contextUsageFromParseResult(result, model),
             });
+            if (discoverSubagents) {
+              if (subagentPoller) await subagentPoller.refresh();
+              else {
+                const file = sessionFile;
+                subagentPoller = await startSubagentListPolling(file, () => new Set(), offer,
+                  () => listCodexSubagents(file, latestWorkLog));
+                if (stopped) subagentPoller.stop();
+              }
+            }
           } catch {
             // Transient parse failure (read during a write) — the next change
             // event re-parses cleanly.
@@ -222,6 +237,8 @@ export function streamResolvedFullParseSnapshots(
               // First resolution, or a newer transcript appeared — point the
               // watcher at it and re-parse.
               if (watcher) { try { watcher.close(); } catch { /* ignore */ } watcher = null; }
+              subagentPoller?.stop();
+              subagentPoller = null;
               sessionFile = resolved;
               await emit();
               if (!stopped) watchFile(resolved);
@@ -245,6 +262,7 @@ export function streamResolvedFullParseSnapshots(
         return {
           stop: () => {
             stopped = true;
+            subagentPoller?.stop();
             if (discoveryTimer) { clearInterval(discoveryTimer); discoveryTimer = null; }
             if (debounce) { clearTimeout(debounce); debounce = null; }
             if (watcher) { try { watcher.close(); } catch { /* ignore */ } }
@@ -264,6 +282,7 @@ export function streamHarnessFullParseSnapshots(
   model: string | null,
   unresolvedMeansEmpty = false,
   workspace: string | null = null,
+  agentId?: string,
 ): FullParseSnapshotStream | null {
   const behavior = getHarnessBehavior(harness as Parameters<typeof getHarnessBehavior>[0]);
   const streamResolved = (
@@ -277,9 +296,13 @@ export function streamHarnessFullParseSnapshots(
       () => resolvePiSessionPath(sessionName),
       file => runDashboardDbJob('parseTranscriptSnapshot', { sessionFile: file, parser: harness === 'pi' ? 'pi' : 'ohmypi' }),
     );
-    case 'codex-rollout-jsonl': return streamResolved(
-      () => resolveCodexRolloutPath(sessionName),
+    case 'codex-rollout-jsonl': return streamResolvedFullParseSnapshots(
+      async () => {
+        const parent = await resolveCodexRolloutPath(sessionName);
+        return parent && agentId !== undefined ? resolveCodexSubagentTranscript(parent, agentId) : parent;
+      },
       file => runDashboardDbJob('parseTranscriptSnapshot', { sessionFile: file, parser: 'codex' }),
+      model, unresolvedMeansEmpty, agentId === undefined,
     );
     case 'acp-jsonl': return streamResolved(
       () => resolveAcpTranscriptPath(sessionName),
@@ -825,7 +848,7 @@ const PanRpcLayer = PanRpcGroup.toLayer(
             // streaming for pi/codex here.
             if (!conv && /^(agent-|planning-|specialist-|strike-|inspect-)|^(flywheel-orchestrator|conv-flywheel-orchestrator)$/.test(input.conversationName)) {
               const harness = yield* Effect.promise(() => resolveAgentHarness(input.conversationName));
-              const stream = streamHarnessFullParseSnapshots(input.conversationName, harness, null);
+              const stream = streamHarnessFullParseSnapshots(input.conversationName, harness, null, false, null, input.agentId);
               if (stream) return stream;
               return conversationDiscoveringStream();
             }
@@ -834,7 +857,7 @@ const PanRpcLayer = PanRpcGroup.toLayer(
               return conversationDiscoveringStream();
             }
 
-            const stream = streamHarnessFullParseSnapshots(conv.tmuxSession, conv.harness, conv.model ?? null, true, conv.cwd ?? null);
+            const stream = streamHarnessFullParseSnapshots(conv.tmuxSession, conv.harness, conv.model ?? null, true, conv.cwd ?? null, input.agentId);
             if (stream) return stream;
 
             if (getHarnessBehavior(conv.harness).transcriptKind !== 'claude-jsonl') {

--- a/src/lib/overdeck/conversation-reads.ts
+++ b/src/lib/overdeck/conversation-reads.ts
@@ -48,6 +48,7 @@ import { isPiSessionFile, parsePiConversationMessages } from '../../dashboard/se
 import { isOhmypiSessionFile, parseOhmypiConversationMessages } from '../../dashboard/server/services/ohmypi-conversation-parser.js';
 import { parseCodexConversationMessages } from '../../dashboard/server/services/codex-conversation-parser.js';
 import { isCompacting } from '../../dashboard/server/services/conversation-compaction.js';
+import { listCodexSubagents, resolveCodexSubagentTranscript } from '../../dashboard/server/services/conversation/codex-subagents.js';
 import { listSubagentMetas, subagentTranscriptPath } from '../../dashboard/server/services/conversation/subagents.js';
 import {
   readLauncherPinnedSessionId,
@@ -624,7 +625,9 @@ export async function getConversationMessagesRead(
 
     const parentSessionFile = sessionFile;
     if (agentId !== undefined) {
-      sessionFile = subagentTranscriptPath(parentSessionFile, agentId);
+      sessionFile = isCodexSessionFile(parentSessionFile)
+        ? await resolveCodexSubagentTranscript(parentSessionFile, agentId)
+        : subagentTranscriptPath(parentSessionFile, agentId);
       if (!sessionFile) return result({ error: 'Invalid subagent id' }, 400);
     }
 
@@ -643,7 +646,9 @@ export async function getConversationMessagesRead(
         }
       }
       const subagents = agentId === undefined
-        ? (await listSubagentMetas(parentSessionFile)).map((meta) => ({ ...meta, status: 'done' as const }))
+        ? isCodexSessionFile(parentSessionFile)
+          ? await listCodexSubagents(parentSessionFile, parsed.workLog)
+          : (await listSubagentMetas(parentSessionFile)).map((meta) => ({ ...meta, status: 'done' as const }))
         : undefined;
 
       return result({

--- a/tests/unit/dashboard/server/routes/conversation-subagent-messages.test.ts
+++ b/tests/unit/dashboard/server/routes/conversation-subagent-messages.test.ts
@@ -154,6 +154,32 @@ describe('conversation subagent list emission', () => {
     expect(subagent.subagents).toBeUndefined();
   });
 
+  it('returns Codex children and reads the selected child instead of the parent', async () => {
+    const name = createConversationRecord();
+    const folder = join(tempDir, 'codex-home', 'sessions', '2026', '09', '08');
+    await mkdir(folder, { recursive: true });
+    sessionFile = join(folder, 'rollout-parent.jsonl');
+    const childFile = join(folder, 'rollout-child.jsonl');
+    for (const [file, id, source, message] of [
+      [sessionFile, 'parent', 'cli', 'Parent output'],
+      [childFile, 'child', { subagent: { thread_spawn: { parent_thread_id: 'parent', depth: 1 } } }, 'Child output'],
+    ] as const) {
+      await writeFile(file, [
+        { type: 'session_meta', payload: { id, source } },
+        { type: 'event_msg', payload: { type: 'agent_message', message } },
+        { type: 'event_msg', payload: { type: 'task_complete' } },
+      ].map(entry => JSON.stringify(entry)).join('\n') + '\n');
+    }
+    expect((await readMessages(name)).body).toMatchObject({
+      messages: [{ text: 'Parent output' }], subagents: [{ agentId: 'child', status: 'done' }],
+    });
+    const child = await readMessages(name, 'child');
+    expect(child.body).toMatchObject({ messages: [{ text: 'Child output' }] });
+    expect((child.body as Record<string, unknown>).subagents).toBeUndefined();
+    expect((await readMessages(name, 'parent')).status).toBe(400);
+    expect((await readMessages(name, '../child')).status).toBe(400);
+  });
+
   it('rejects traversal-unsafe subagent ids before parsing a transcript', async () => {
     const name = createConversationRecord();
     await writeFile(sessionFile, '');

--- a/tests/unit/dashboard/server/services/conversation/codex-subagents.test.ts
+++ b/tests/unit/dashboard/server/services/conversation/codex-subagents.test.ts
@@ -1,0 +1,107 @@
+import { appendFile, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ConversationEvent } from '@overdeck/contracts';
+import { listCodexSubagents, resolveCodexSubagentTranscript } from '../../../../../../src/dashboard/server/services/conversation/codex-subagents.js';
+import { startSubagentListPolling, type SubagentListPoller } from '../../../../../../src/dashboard/server/services/conversation/subagents.js';
+import { parseCodexConversationMessages } from '../../../../../../src/dashboard/server/services/codex-conversation-parser.js';
+
+let dir: string;
+let parent: string;
+let poller: SubagentListPoller | undefined;
+const event = (type: string) => JSON.stringify({ type: 'event_msg', payload: { type } }) + '\n';
+async function thread(id: string, parentId?: string, day = '08'): Promise<string> {
+  const folder = join(dir, 'sessions', '2026', '09', day);
+  await mkdir(folder, { recursive: true });
+  const file = join(folder, `rollout-2026-09-${day}T00-00-00-${id}.jsonl`);
+  await writeFile(file, JSON.stringify({ type: 'session_meta', payload: {
+    id, source: parentId ? { subagent: { thread_spawn: {
+      parent_thread_id: parentId, depth: 9, agent_path: `/root/${id}`, agent_nickname: 'Euler',
+    } } } : 'cli',
+  } }) + '\n' + event('task_started'));
+  return file;
+}
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'codex-subagents-'));
+  parent = await thread('parent');
+});
+afterEach(async () => {
+  poller?.stop();
+  poller = undefined;
+  vi.useRealTimers();
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe('Codex child threads', () => {
+  it('lists only descendants, computes relative depth, and resolves across date directories', async () => {
+    const child = await thread('child', 'parent', '09');
+    const grandchild = await thread('grandchild', 'child', '07');
+    await thread('unrelated', 'another-parent');
+    expect(await listCodexSubagents(parent)).toEqual([
+      expect.objectContaining({ agentId: 'child', spawnDepth: 1, status: 'running' }),
+      expect.objectContaining({ agentId: 'grandchild', spawnDepth: 2 }),
+    ]);
+    expect(await resolveCodexSubagentTranscript(parent, 'child')).toBe(child);
+    expect(await resolveCodexSubagentTranscript(parent, 'grandchild')).toBe(grandchild);
+    for (const id of ['unrelated', 'parent', '../child', '/etc/passwd', '']) {
+      expect(await resolveCodexSubagentTranscript(parent, id)).toBeNull();
+    }
+  });
+
+  it('joins spawn rows by returned thread ID or collaboration task path', async () => {
+    await thread('child', 'parent');
+    for (const output of [{ agent_id: 'child' }, { task_name: '/root/child' }]) {
+      await writeFile(parent, JSON.stringify({ type: 'session_meta', payload: { id: 'parent' } }) + '\n'
+        + JSON.stringify({ type: 'response_item', payload: {
+          type: 'function_call', name: 'spawn_agent', call_id: 'spawn-1', arguments: JSON.stringify({ task_name: 'Read parser' }),
+        } }) + '\n'
+        + JSON.stringify({ type: 'response_item', payload: {
+          type: 'function_call_output', call_id: 'spawn-1', output: JSON.stringify(output),
+        } }) + '\n');
+      const parsed = await parseCodexConversationMessages(parent);
+      expect(parsed.workLog[0].toolInput).toEqual({ task_name: 'Read parser' });
+      expect(await listCodexSubagents(parent, parsed.workLog)).toEqual([
+        expect.objectContaining({ agentId: 'child', toolUseId: 'spawn-1', description: 'Read parser' }),
+      ]);
+    }
+  });
+
+  it('does not follow symlinks or list ordinary conversation forks', async () => {
+    const outside = join(dir, 'outside');
+    await mkdir(outside);
+    await writeFile(join(outside, 'rollout-evil.jsonl'), JSON.stringify({ type: 'session_meta', payload: {
+      id: 'evil', source: { subagent: { thread_spawn: { parent_thread_id: 'parent' } } },
+    } }) + '\n');
+    await symlink(outside, join(dir, 'sessions', 'linked'));
+    await symlink(join(outside, 'rollout-evil.jsonl'), join(dir, 'sessions', 'rollout-linked.jsonl'));
+    const fork = await thread('fork');
+    await writeFile(fork, JSON.stringify({ type: 'session_meta', payload: { id: 'fork', forked_from_id: 'parent' } }) + '\n');
+    expect(await listCodexSubagents(parent)).toEqual([]);
+  });
+
+  it('discovers late files and refreshes child completion and follow-up without parent writes', async () => {
+    vi.useFakeTimers();
+    const events: ConversationEvent[] = [];
+    poller = await startSubagentListPolling(parent, () => new Set(), e => events.push(e), () => listCodexSubagents(parent));
+    const child = await thread('child', 'parent');
+    await vi.advanceTimersByTimeAsync(2000);
+    await poller.refresh();
+    expect(events.at(-1)).toMatchObject({ kind: 'subagents', subagents: [{ status: 'running' }] });
+    await appendFile(child, event('task_complete'));
+    await poller.refresh();
+    expect(events.at(-1)).toMatchObject({ kind: 'subagents', subagents: [{ status: 'done' }] });
+    await appendFile(child, event('task_started'));
+    await poller.refresh();
+    expect(events.at(-1)).toMatchObject({ kind: 'subagents', subagents: [{ status: 'running' }] });
+    const count = events.length;
+    await poller.refresh();
+    expect(events).toHaveLength(count);
+    poller.stop();
+    await appendFile(child, event('turn_aborted'));
+    await vi.advanceTimersByTimeAsync(4000);
+    await poller.refresh();
+    expect(events).toHaveLength(count);
+  });
+});


### PR DESCRIPTION
Codex conversations now show child agents in the existing Agents rail. Selecting a child opens its live transcript; completed conversations support the same selection over HTTP. Expanded `spawn_agent` rows link to the child while preserving all spawn arguments and tool results.

Discovery follows Codex's recorded parent thread IDs within the parent's sessions tree, includes nested children, and rejects unrelated IDs and symlinks. Child status refreshes independently of parent activity. Claude Code's existing discovery and transcript behavior remain covered by regression tests. User and developer documentation are updated.

Validation:
- `npm test`: 14,058 backend tests and 64 required frontend tests passed.
- Focused final regression run: 31 backend and 33 frontend tests passed.
- `npm run build` and `npm run typecheck` passed; existing type baselines did not grow.
- All lint stages passed. The circular-dependency stage was rerun after removing the temporary browser preview, followed by the remaining lint stages; no baselines changed.
- Playwright verified child selection, transcript rendering, URL selection, and returning to the parent in an isolated preview. Screenshots were inspected.
- Read-only discovery against an existing Codex conversation found 17 child threads.

Status uses the most recent lifecycle event in a bounded 128 KiB transcript tail; without a terminal event there, a child is shown as running. Merged and deployed locally at `517e381be381803d20d53c20a2fe61514dc16395`. Live health and Playwright checks passed, including real Codex child selection and returning to the parent. Deployment was serialized with conversation 2648.

CI note: all 13,977 assertions passed in the initial GitHub run, but Vitest reported an `EnvironmentTeardownError` while closing console RPC in the unchanged `review-status-retirement.test.ts`. That file passes locally with `CI=true`; the failed job was rerun.
