### PR TITLE
feat(dashboard): direct subagent composer and live working indicators

### DIFF
--- a/docs/CONVERSATION-SUBAGENTS.md
+++ b/docs/CONVERSATION-SUBAGENTS.md
@@ -98,3 +98,35 @@ Selection accepts only safe IDs and requires membership in the parent's verified
 descendant tree. It never interprets an ID as a path, follows directory/file
 symlinks during discovery, or searches another Codex home. Missing or unrelated
 IDs cannot fall back to the parent transcript. All discovery and reads are asynchronous.
+
+### Child activity
+
+Selected subagent transcripts show the same animated “Working for …” row as
+main conversations, including the tool activity icon. Codex child activity comes
+from its own task lifecycle in the subagent list: Codex transcript snapshots have
+`streaming: false`, so that field cannot override a running child. Claude Code
+also uses the child stream's activity. Ended or disconnected parent sessions do
+not display stale child activity. The main agent's busy state does not determine
+whether a selected child is working.
+
+### Direct child composer
+
+The bottom composer appears only when the live Codex app-server host confirms
+that the selected child belongs to its primary thread and is loaded with an
+idle or active turn. Active turns receive `turn/steer` with the exact expected
+turn ID; idle children receive `turn/start` with the child's thread ID. Child
+notifications do not replace the host's primary thread or active turn. Input
+inherits the child's existing model and permissions.
+
+`GET /api/conversations/:name/subagents/:agentId/input` checks capability.
+`POST` to the same route accepts `{ "message": "..." }` and revalidates membership
+and availability. Input is literal text, including slash-prefixed text; parent
+composer commands are not intercepted. Drafts use a separate per-child key.
+The UI clears a draft only after the host acknowledges the selected recipient.
+An uncertain send is never automatically retried.
+
+Claude Code PTY sessions, Codex TUI sessions, old hosts, and unloaded children
+remain read-only. There is no relay through the parent, automatic replacement
+thread, or second process resuming a live transcript. A host upgrade requires
+restarting that conversation before its new operations are available; reloading
+the dashboard alone does not update an already-running host.

--- a/features/conversations.mdx
+++ b/features/conversations.mdx
@@ -265,3 +265,20 @@ and the original's context is never lost.
 - [Harnesses](/configuration/harnesses) — `claude-code` vs `pi`, and the ToS rules that gate them
 - `pan conv current` (alias `pan conv whoami`) — print the conversation you're running inside
 - `pan fork [conv]` — create a summary or plain fork without asking the source agent to author a handoff
+
+## Subagent activity and direct messages
+
+Select a child in the conversation's agent rail to read its transcript. Active
+children display “Working for …” with the same activity indicator as the main
+conversation.
+
+A bottom composer appears when the selected child supports direct messages.
+For Codex, this requires a loaded child in a conversation running the structured
+app-server transport. Messages go to that child's existing thread, with its
+current model and permissions. Drafts are separate for each child.
+
+Claude Code sessions, Codex terminal sessions, and unavailable children show the
+transcript without a composer. Messages are never relayed through the main agent.
+Existing Codex conversations need a restart after upgrading their host before
+they can expose this capability. If delivery cannot be confirmed, check the
+child's transcript before retrying.

--- a/scripts/file-size-allowlist.txt
+++ b/scripts/file-size-allowlist.txt
@@ -70,3 +70,6 @@
 1531 src/dashboard/frontend/src/components/chat/ConversationPanel.tsx # PAN-3773
 1189 src/dashboard/server/routes/settings.ts # PAN-3771
 1578 src/lib/model-capabilities.ts # PAN-3780
+
+# Two registration lines; implementation is in the extracted child input route module.
+1072 src/dashboard/server/routes/conversations.ts # PAN-3787

--- a/src/dashboard/frontend/src/components/chat/ComposerPromptEditor.tsx
+++ b/src/dashboard/frontend/src/components/chat/ComposerPromptEditor.tsx
@@ -186,6 +186,7 @@ function EditorRefPlugin({ editorRef }: EditorRefPluginProps) {
 export interface ComposerPromptEditorProps {
   conversationName: string;
   harness?: Harness;
+  slashCommandsEnabled?: boolean;
   disabled?: boolean;
   placeholder?: string;
   onCommandKeyDown: (key: 'Enter') => void;
@@ -335,6 +336,7 @@ export function SlashMenu({ commands, filter, selectedIndex, onSelect, onClose, 
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function ComposerPromptEditor({
+  slashCommandsEnabled = true,
   conversationName,
   harness = 'claude-code',
   disabled = false,
@@ -391,13 +393,14 @@ export function ComposerPromptEditor({
     };
   }, [text]);
 
-  const slashCommands = useMemo(() => getSlashCommands(harness), [harness]);
+  const slashCommands = useMemo(() => slashCommandsEnabled ? getSlashCommands(harness) : [], [harness, slashCommandsEnabled]);
   const filteredCommands = useMemo(
     () => filterCommands(slashCommands, slashContext?.filterText ?? ''),
     [slashCommands, slashContext],
   );
 
   const handleSlashKey = useCallback((root: HTMLElement) => {
+    if (!slashCommandsEnabled) return;
     const selection = window.getSelection();
     let anchorRect: DOMRect | null = null;
 
@@ -417,7 +420,7 @@ export function ComposerPromptEditor({
     pendingSlashTriggerRef.current = true;
     setIsSlashMenuOpen(true);
     setSelectedIndex(0);
-  }, []);
+  }, [slashCommandsEnabled]);
 
   const handleSlashSelect = useCallback(
     (command: SlashCommand) => {

--- a/src/dashboard/frontend/src/components/chat/SubagentComposer.test.tsx
+++ b/src/dashboard/frontend/src/components/chat/SubagentComposer.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Conversation } from '../CommandDeck/ConversationList';
+import { SubagentComposer } from './SubagentComposer';
+
+vi.mock('./ComposerPromptEditor', () => ({
+  loadDraft: () => '',
+  ComposerPromptEditor: ({ onChange, disabled, placeholder }: { onChange: (text: string) => void; disabled: boolean; placeholder: string }) => (
+    <textarea disabled={disabled} placeholder={placeholder} onChange={event => onChange(event.target.value)} />
+  ),
+}));
+const conversation = { name: 'parent', harness: 'codex', sessionAlive: true, endedAt: null } as Conversation;
+const child = { agentId: 'child', agentType: 'Avicenna', description: 'Audit', toolUseId: 'call-1', spawnDepth: 1, status: 'running' as const };
+function renderComposer(parent = conversation) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}><SubagentComposer conversation={parent} subagent={child} /></QueryClientProvider>);
+}
+const fetchMock = vi.fn();
+beforeEach(() => { fetchMock.mockReset(); vi.stubGlobal('fetch', fetchMock); });
+afterEach(() => vi.unstubAllGlobals());
+
+describe('SubagentComposer', () => {
+  it('does not render a composer while capability is unknown or unavailable', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ direct: false }) });
+    renderComposer();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+  it.each(['claude-code', 'pi'] as const)('does not offer a relay or probe for %s', harness => {
+    renderComposer({ ...conversation, harness });
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+  it('submits only to the selected child and acknowledges its recipient', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ direct: true }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ ok: true, threadId: 'child' }) });
+    renderComposer();
+    const user = userEvent.setup();
+    await user.type(await screen.findByRole('textbox'), 'Please check this');
+    await user.click(screen.getByRole('button', { name: 'Send to Avicenna' }));
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/conversations/parent/subagents/child/input', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ message: 'Please check this' }),
+    });
+    expect(await screen.findByRole('status')).toHaveTextContent('Sent to Avicenna.');
+  });
+  it('keeps failed text and does not automatically retry an uncertain delivery', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ direct: true }) })
+      .mockResolvedValueOnce({ ok: false, json: async () => ({ error: 'Check the transcript before retrying.' }) });
+    renderComposer();
+    const user = userEvent.setup();
+    await user.type(await screen.findByRole('textbox'), 'Keep this draft');
+    await user.click(screen.getByRole('button', { name: 'Send to Avicenna' }));
+    expect(await screen.findByRole('alert')).toHaveTextContent('Check the transcript');
+    expect(screen.getByRole('textbox')).toHaveValue('Keep this draft');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/dashboard/frontend/src/components/chat/SubagentComposer.tsx
+++ b/src/dashboard/frontend/src/components/chat/SubagentComposer.tsx
@@ -1,0 +1,79 @@
+import { useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { $getRoot, type LexicalEditor } from 'lexical';
+import { SendHorizontal } from 'lucide-react';
+import { ComposerPromptEditor, loadDraft } from './ComposerPromptEditor';
+import type { Conversation } from '../CommandDeck/ConversationList';
+import type { SubagentSummary } from './chat-types';
+import styles from '../CommandDeck/styles/command-deck.module.css';
+
+/** Mount with a child-specific key: sends and drafts must never cross recipients. */
+export function SubagentComposer({ conversation, subagent }: { conversation: Conversation; subagent: SubagentSummary }) {
+  const queryClient = useQueryClient();
+  const draftKey = `${conversation.name}:subagent:${subagent.agentId}`;
+  const endpoint = `/api/conversations/${encodeURIComponent(conversation.name)}/subagents/${encodeURIComponent(subagent.agentId)}/input`;
+  const editorRef = useRef<LexicalEditor | null>(null);
+  const sendingRef = useRef(false);
+  const [text, setText] = useState(() => loadDraft(draftKey));
+  const [sending, setSending] = useState(false);
+  const [feedback, setFeedback] = useState('');
+  const [failed, setFailed] = useState(false);
+  const capability = useQuery({
+    queryKey: ['subagent-input', conversation.name, subagent.agentId],
+    enabled: conversation.harness === 'codex' && conversation.sessionAlive && !conversation.endedAt,
+    queryFn: async () => {
+      const response = await fetch(endpoint);
+      if (!response.ok) return false;
+      const body = await response.json();
+      return body.direct === true;
+    },
+    retry: false,
+    refetchInterval: 5_000,
+    staleTime: 0,
+  });
+
+  async function send() {
+    if (!text.trim() || sendingRef.current || capability.data !== true) return;
+    sendingRef.current = true;
+    setSending(true);
+    setFeedback('');
+    setFailed(false);
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ message: text }),
+      });
+      const body = await response.json();
+      if (!response.ok || body.ok !== true || body.threadId !== subagent.agentId) {
+        throw new Error(body.error || 'Could not confirm delivery. Check the child transcript before retrying.');
+      }
+      editorRef.current?.update(() => { $getRoot().clear(); });
+      setText('');
+      setFeedback(`Sent to ${subagent.agentType}.`);
+      void queryClient.invalidateQueries({ queryKey: ['conversation-messages', conversation.name, 'subagent', subagent.agentId] });
+    } catch (error) {
+      setFailed(true);
+      setFeedback(error instanceof Error ? error.message : 'Could not confirm delivery. Check the child transcript before retrying.');
+    } finally {
+      sendingRef.current = false;
+      setSending(false);
+    }
+  }
+
+  // No placeholder composer for unsupported harnesses, old hosts, or unloaded children.
+  if (!conversation.sessionAlive || conversation.endedAt || conversation.harness !== 'codex' || capability.isError || capability.data !== true) return null;
+  return (
+    <div className={styles.composerFooter}>
+      <div className="px-3 pt-2 text-xs text-muted-foreground">Message {subagent.agentType} directly</div>
+      <ComposerPromptEditor conversationName={draftKey} harness="codex" slashCommandsEnabled={false}
+        editorRef={editorRef} disabled={sending} onChange={setText} onCommandKeyDown={() => void send()}
+        placeholder={`Message ${subagent.agentType}…`} />
+      <div className="flex items-center justify-end gap-2 px-3 pb-2">
+        {feedback && <span role={failed ? 'alert' : 'status'} className="mr-auto text-xs">{feedback}</span>}
+        <button type="button" aria-label={`Send to ${subagent.agentType}`} disabled={sending || !text.trim()}
+          className="rounded-md bg-primary p-2 text-primary-foreground disabled:opacity-50" onClick={() => void send()}>
+          <SendHorizontal size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/dashboard/frontend/src/components/chat/SubagentTranscript.test.tsx
+++ b/src/dashboard/frontend/src/components/chat/SubagentTranscript.test.tsx
@@ -9,9 +9,10 @@ const hookMocks = vi.hoisted(() => ({ useSubagentTranscript: vi.fn() }));
 vi.mock('./useConversationMessagesStream', () => ({
   useSubagentTranscript: hookMocks.useSubagentTranscript,
 }));
+vi.mock('./SubagentComposer', () => ({ SubagentComposer: () => null }));
 vi.mock('./MessagesTimeline', () => ({
-  MessagesTimeline: ({ messages }: { messages: Array<{ text: string }> }) => (
-    <div data-testid="subagent-timeline">{messages.map((message) => message.text).join(' ')}</div>
+  MessagesTimeline: ({ messages, streaming }: { messages: Array<{ text: string }>; streaming: boolean }) => (
+    <div data-testid="subagent-timeline" data-working={streaming}>{messages.map((message) => message.text).join(' ')}</div>
   ),
 }));
 
@@ -53,13 +54,26 @@ describe('SubagentTranscript', () => {
     });
   });
 
-  it('renders the selected subagent transcript without a composer', () => {
+  it('renders the selected subagent transcript', () => {
     render(<SubagentTranscript conversation={conversation} subagent={subagent} onBack={vi.fn()} />);
 
     expect(screen.getByText(/Explore/)).toHaveTextContent('Explore · Trace the conversation parser');
     expect(screen.getByTestId('subagent-timeline')).toHaveTextContent('Subagent transcript');
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
     expect(hookMocks.useSubagentTranscript).toHaveBeenLastCalledWith(conversation, 'alpha');
+  });
+
+  it.each(['codex', 'claude-code'] as const)('shows activity for a running %s child despite a non-streaming snapshot, and clears it on completion', (harness) => {
+    const parent = { ...conversation, harness };
+    const { rerender } = render(<SubagentTranscript conversation={parent} subagent={subagent} onBack={vi.fn()} />);
+    expect(screen.getByTestId('subagent-timeline')).toHaveAttribute('data-working', 'true');
+    rerender(<SubagentTranscript conversation={parent} subagent={{ ...subagent, status: 'done' }} onBack={vi.fn()} />);
+    expect(screen.getByTestId('subagent-timeline')).toHaveAttribute('data-working', 'false');
+  });
+
+  it('does not show stale activity after the parent session ends', () => {
+    render(<SubagentTranscript conversation={{ ...conversation, endedAt: '2026-07-18T00:02:00Z', sessionAlive: false }} subagent={subagent} onBack={vi.fn()} />);
+    expect(screen.getByTestId('subagent-timeline')).toHaveAttribute('data-working', 'false');
   });
 
   it('gives the timeline a flex-column parent so it can scroll', () => {

--- a/src/dashboard/frontend/src/components/chat/SubagentTranscript.tsx
+++ b/src/dashboard/frontend/src/components/chat/SubagentTranscript.tsx
@@ -1,7 +1,9 @@
 import { ArrowLeft, Loader2 } from 'lucide-react';
 import type { Conversation } from '../CommandDeck/ConversationList';
+import { SubagentComposer } from './SubagentComposer';
 import { MessagesTimeline } from './MessagesTimeline';
 import type { SubagentSummary } from './chat-types';
+import { getWorkingPhase } from '../../lib/workingPhase';
 import { useSubagentTranscript } from './useConversationMessagesStream';
 import styles from '../CommandDeck/styles/command-deck.module.css';
 
@@ -15,11 +17,14 @@ interface SubagentTranscriptProps {
 
 /**
  * Full-width transcript for one subagent. Rendered in place of the parent
- * conversation body while a rail row is selected — no composer, because a
- * subagent has no input channel of its own.
+ * conversation body while a rail row is selected. Direct input is capability-gated.
  */
 export function SubagentTranscript({ conversation, subagent, resolvedTheme, onBack }: SubagentTranscriptProps) {
   const transcript = useSubagentTranscript(conversation, subagent.agentId);
+  // Codex snapshots deliberately report streaming=false. Child lifecycle comes
+  // from the subagent list; the parent's activity must never light up this view.
+  const isWorking = !conversation.endedAt && conversation.sessionAlive
+    && (subagent.status === 'running' || (conversation.harness !== 'codex' && transcript.data?.streaming === true));
 
   return (
     <div className={`${styles.subagentTranscript} flex min-h-0 min-w-0 flex-1 flex-col`}>
@@ -53,7 +58,8 @@ export function SubagentTranscript({ conversation, subagent, resolvedTheme, onBa
           <MessagesTimeline
             messages={transcript.data?.messages ?? []}
             workLog={transcript.data?.workLog ?? []}
-            streaming={transcript.data?.streaming ?? subagent.status === 'running'}
+            streaming={isWorking}
+            workingPhase={isWorking ? getWorkingPhase(transcript.data?.messages ?? [], transcript.data?.workLog ?? []) : undefined}
             conversationName={`${conversation.name}:${subagent.agentId}`}
             cwd={conversation.cwd}
             issueId={conversation.issueId}
@@ -61,6 +67,7 @@ export function SubagentTranscript({ conversation, subagent, resolvedTheme, onBa
           />
         )}
       </div>
+      <SubagentComposer key={`${conversation.name}:${subagent.agentId}`} conversation={conversation} subagent={subagent} />
     </div>
   );
 }

--- a/src/dashboard/frontend/src/components/chat/messagesTimeline/dividers.test.tsx
+++ b/src/dashboard/frontend/src/components/chat/messagesTimeline/dividers.test.tsx
@@ -1,0 +1,21 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import { WorkingIndicator } from './dividers';
+
+describe('WorkingIndicator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-08T12:00:00Z'));
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it('shows elapsed work time and updates while active', () => {
+    const { unmount } = render(<WorkingIndicator startedAt="2026-09-08T11:59:50Z" />);
+    act(() => { vi.advanceTimersByTime(1000); });
+    expect(screen.getByText('Working for 11s')).toBeInTheDocument();
+    act(() => { vi.advanceTimersByTime(2000); });
+    expect(screen.getByText('Working for 13s')).toBeInTheDocument();
+    unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/dashboard/server/routes/conversation-subagent-input.ts
+++ b/src/dashboard/server/routes/conversation-subagent-input.ts
@@ -1,0 +1,33 @@
+import { Effect, Layer } from 'effect';
+import { HttpRouter, HttpServerRequest } from 'effect/unstable/http';
+import { conversationSubagentInput } from '../../../lib/overdeck/conversation-subagent-input.js';
+import { resolveSessionFile } from '../../../lib/overdeck/conversation-reads.js';
+import { jsonResponse } from '../http-helpers.js';
+import { validateOrigin } from './origin-validation.js';
+
+const inputHandler = (send: boolean) => Effect.gen(function* () {
+  const request = yield* HttpServerRequest.HttpServerRequest;
+  const originCheck = validateOrigin(request);
+  if (!originCheck.ok) return jsonResponse({ error: originCheck.error }, { status: 403 });
+  const params = yield* HttpRouter.params;
+  let body: Record<string, unknown> | undefined;
+  if (send) {
+    const text = yield* request.text;
+    try {
+      const parsed: unknown = JSON.parse(text);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('Invalid body');
+      body = parsed as Record<string, unknown>;
+    } catch {
+      return jsonResponse({ error: 'Invalid JSON body' }, { status: 400 });
+    }
+  }
+  const response = yield* Effect.promise(() => conversationSubagentInput(
+    params['name'] ?? '', params['agentId'] ?? '', { resolveSessionFile }, body,
+  ));
+  return jsonResponse(response.body, { status: response.status ?? 200 });
+});
+
+export const conversationSubagentInputRoutes = Layer.mergeAll(
+  HttpRouter.add('GET', '/api/conversations/:name/subagents/:agentId/input', inputHandler(false)),
+  HttpRouter.add('POST', '/api/conversations/:name/subagents/:agentId/input', inputHandler(true)),
+);

--- a/src/dashboard/server/routes/conversations.ts
+++ b/src/dashboard/server/routes/conversations.ts
@@ -1,3 +1,4 @@
+import { conversationSubagentInputRoutes } from './conversation-subagent-input.js';
 import { jsonResponse } from "../http-helpers.js";
 import { BLANKED_PROVIDER_ENV } from '../../../lib/child-env.js';
 import { getClaudePermissionFlagsStringSync, resolvePermissionModeSync, BYPASS_PERMISSION_MODE } from '../../../lib/claude-permissions.js';
@@ -1052,6 +1053,7 @@ export const conversationsRouteLayer = Layer.mergeAll(
   postConversationUploadImageRoute,
   postConversationDeleteImageRoute,
   postConversationMessageRoute,
+  conversationSubagentInputRoutes,
   postConversationCodexApprovalRoute,
   postConversationPaneChoiceRoute,
   postConversationPiAskAnswerRoute,

--- a/src/lib/codex/__tests__/app-server-host.test.ts
+++ b/src/lib/codex/__tests__/app-server-host.test.ts
@@ -152,6 +152,33 @@ describe('CodexAppServerHost', () => {
     vi.restoreAllMocks();
   });
 
+  it('keeps child notification output and activity out of the primary pane', () => {
+    const manager = new FakeManager();
+    manager.setState({ state: 'running', threadId: 'root', activeTurnId: 'root-turn' });
+    const { stdout, lines } = captureStdout();
+    const recordActivity = vi.fn(() => true);
+    makeHost(manager, { stdout, recordActivity });
+    manager.emit('notification', { method: 'item/agentMessage/delta', params: { threadId: 'child', delta: 'child-only output' } });
+    expect(lines.join('\n')).not.toContain('child-only output');
+    expect(recordActivity).not.toHaveBeenCalled();
+  });
+
+  it('routes child operations without invoking the parent message path', async () => {
+    const manager = Object.assign(new FakeManager(), {
+      readSubagentInput: vi.fn(async () => ({ direct: true })),
+      sendSubagentMessage: vi.fn(async () => ({})),
+    });
+    const host = makeHost(manager);
+    expect(await host.handleOp({ op: 'subagent-input', threadId: 'child' })).toEqual({ status: 200, body: { direct: true } });
+    expect(await host.handleOp({ op: 'subagent-message', threadId: 'child', content: 'hello child' })).toEqual({ status: 200, body: { ok: true, threadId: 'child' } });
+    expect(manager.sendSubagentMessage).toHaveBeenCalledWith('child', 'hello child');
+    expect(manager.startThreadCalls).toEqual([]);
+    expect(manager.startTurnCalls).toEqual([]);
+    manager.sendSubagentMessage.mockRejectedValueOnce(new Error('Child no longer available'));
+    expect((await host.handleOp({ op: 'subagent-message', threadId: 'child', content: 'hello child' })).status).toBe(500);
+    expect(manager.startTurnCalls).toEqual([]);
+  });
+
   it('rejects a first message without a model before starting a thread', async () => {
     const manager = new FakeManager();
     const host = makeHost(manager);

--- a/src/lib/codex/__tests__/subagent-input.test.ts
+++ b/src/lib/codex/__tests__/subagent-input.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { CodexAppServerManager } from '../app-server-manager.js';
+import { createFakeAppServer } from './fake-app-server.js';
+
+async function setup(status = 'idle', parent = 'root') {
+  const fake = createFakeAppServer((message, server) => {
+    if (message.method === 'initialize') server.send({ id: message.id, result: {} });
+    if (message.method === 'thread/start') server.send({ id: message.id, result: { thread: { id: 'root' } } });
+    if (message.method === 'thread/read') {
+      const id = (message.params as { threadId: string }).threadId;
+      server.send({ id: message.id, result: { thread: {
+        id, source: { subagent: { thread_spawn: { parent_thread_id: parent } } },
+        status: { type: status }, turns: status === 'active' ? [{ id: 'child-turn', status: 'inProgress' }] : [],
+      } } });
+    }
+    if (message.method === 'turn/start' || message.method === 'turn/steer') server.send({ id: message.id, result: {} });
+  });
+  const manager = new CodexAppServerManager({ cwd: '/tmp', readVersion: async () => '0.144.1', spawnProcess: () => fake.child });
+  await manager.start();
+  await manager.startThread({ model: 'configured-model' });
+  return { manager, fake };
+}
+
+describe('direct Codex child input', () => {
+  it.each(['idle', 'active'])('sends to the %s child without changing the primary thread or model', async status => {
+    const { manager, fake } = await setup(status);
+    try {
+      await manager.sendSubagentMessage('child', 'Follow up');
+      const request = fake.messages.findLast(message => message.method === (status === 'active' ? 'turn/steer' : 'turn/start'));
+      expect(request?.params).toEqual({ threadId: 'child', input: [{ type: 'text', text: 'Follow up', text_elements: [] }],
+        ...(status === 'active' ? { expectedTurnId: 'child-turn' } : {}),
+      });
+      expect(manager.getState().threadId).toBe('root');
+      expect(fake.messages.some(message => message.method === 'thread/resume')).toBe(false);
+    } finally { manager.stop(); }
+  });
+
+  it.each(['notLoaded', 'systemError'])('rejects %s children without resuming or creating a turn', async status => {
+    const { manager, fake } = await setup(status);
+    try {
+      expect(await manager.readSubagentInput('child')).toEqual({ direct: false });
+      await expect(manager.sendSubagentMessage('child', 'Follow up')).rejects.toThrow('unavailable');
+      expect(fake.messages.filter(message => message.method?.startsWith('turn/'))).toEqual([]);
+    } finally { manager.stop(); }
+  });
+
+  it('rejects the root and unrelated children', async () => {
+    const { manager, fake } = await setup('idle', 'unrelated');
+    try {
+      expect(await manager.readSubagentInput('root')).toEqual({ direct: false });
+      await expect(manager.sendSubagentMessage('child', 'Follow up')).rejects.toThrow('unavailable');
+      expect(fake.messages.filter(message => message.method?.startsWith('turn/'))).toEqual([]);
+    } finally { manager.stop(); }
+  });
+
+  it('does not let child notifications replace parent runtime state', async () => {
+    const { manager, fake } = await setup();
+    try {
+      fake.send({ method: 'turn/started', params: { threadId: 'root', turn: { id: 'parent-turn' } } });
+      const parentState = manager.getState();
+      fake.send({ method: 'thread/started', params: { thread: { id: 'child' } } });
+      fake.send({ method: 'turn/started', params: { threadId: 'child', turn: { id: 'child-turn' } } });
+      fake.send({ method: 'turn/completed', params: { threadId: 'child' } });
+      fake.send({ method: 'error', params: { threadId: 'child', willRetry: false } });
+      expect(manager.getState()).toEqual(parentState);
+    } finally { manager.stop(); }
+  });
+});

--- a/src/lib/codex/app-server-host.ts
+++ b/src/lib/codex/app-server-host.ts
@@ -36,6 +36,8 @@ interface AppServerHostManager extends EventEmitter {
   resumeThread(threadId: string, options: ThreadOptions): Promise<unknown>;
   startTurn(text: string, options?: TurnOptions): Promise<unknown>;
   interruptTurn(): Promise<unknown>;
+  readSubagentInput?(threadId: string): Promise<{ direct: boolean; activeTurnId?: string }>;
+  sendSubagentMessage?(threadId: string, text: string): Promise<unknown>;
   answerApproval(id: string | number, decision: string): void;
   answerUserInput(id: string | number, answers: Record<string, string[]>): void;
 }
@@ -148,6 +150,18 @@ export class CodexAppServerHost {
         this.effort = body.effort;
         return { status: 200, body: { ok: true, effort: this.effort } };
       }
+      if (name === 'subagent-input' || name === 'subagent-message') {
+        const threadId = body.threadId;
+        if (typeof threadId !== 'string' || !threadId) return { status: 400, body: { error: 'threadId is required' } };
+        if (!this.manager.readSubagentInput || !this.manager.sendSubagentMessage) return { status: 200, body: { direct: false } };
+        if (name === 'subagent-input') return { status: 200, body: await this.manager.readSubagentInput(threadId) };
+        if (typeof body.content !== 'string' || !body.content.trim() || body.content.length > 50_000) {
+          return { status: 400, body: { error: 'A message of at most 50000 characters is required' } };
+        }
+        await this.manager.sendSubagentMessage(threadId, body.content);
+        await this.appendEvent('op/subagent-message', { threadId });
+        return { status: 200, body: { ok: true, threadId } };
+      }
       if (name === 'message') return await this.handleMessageOp(body);
       if (name === 'interrupt') return await this.handleInterruptOp();
       if (name === 'approval') return this.handleApprovalOp(body);
@@ -234,9 +248,11 @@ export class CodexAppServerHost {
   private attachManagerEvents(): void {
     this.manager.on('notification', (message: AppServerMessage) => {
       const threadId = extractThreadId(message);
-      if (message.method === 'thread/started' && threadId) writeThreadId(this.options.agentId, threadId);
-      this.renderNotification(message);
-      this.recordObservedActivity(message);
+      if (message.method === 'thread/started' && threadId && threadId === this.manager.getState().threadId) writeThreadId(this.options.agentId, threadId);
+      if (!threadId || threadId === this.manager.getState().threadId) {
+        this.renderNotification(message);
+        this.recordObservedActivity(message);
+      }
       void this.appendEvent('notification', message as JsonRecord);
     });
     this.manager.on('request', (message: AppServerMessage) => {

--- a/src/lib/codex/app-server-manager.ts
+++ b/src/lib/codex/app-server-manager.ts
@@ -140,6 +140,45 @@ export class CodexAppServerManager extends EventEmitter {
     return this.request('thread/read', { threadId, includeTurns: true });
   }
 
+  /** Read-only capability check. Never resumes or forks a child as a side effect. */
+  async readSubagentInput(threadId: string, includeTurns = false): Promise<{ direct: boolean; activeTurnId?: string }> {
+    const root = this.sessionState.threadId;
+    if (!root || threadId === root) return { direct: false };
+    const child = asRecord(asRecord(await this.request('thread/read', { threadId, includeTurns })).thread);
+    if (child.id !== threadId) return { direct: false };
+    const seen = new Set<string>([threadId]);
+    let current = child;
+    // Verify the entire ancestor chain, including nested subagents. Ordinary
+    // forks do not establish membership in this parent's child tree.
+    for (;;) {
+      const spawn = asRecord(asRecord(asRecord(current.source).subagent).thread_spawn);
+      const parent = typeof spawn.parent_thread_id === 'string' ? spawn.parent_thread_id : current.parentThreadId;
+      if (parent === root) break;
+      if (typeof parent !== 'string' || seen.has(parent) || seen.size >= 64) return { direct: false };
+      seen.add(parent);
+      current = asRecord(asRecord(await this.request('thread/read', { threadId: parent, includeTurns: false })).thread);
+      if (current.id !== parent) return { direct: false };
+    }
+    const status = asRecord(child.status).type;
+    const turns = Array.isArray(child.turns) ? child.turns.map(asRecord) : [];
+    const activeTurn = turns.findLast(turn => turn.status === 'inProgress');
+    if (status === 'active' && !includeTurns) return { direct: true };
+    if (status === 'active' && typeof activeTurn?.id === 'string') {
+      return { direct: true, activeTurnId: activeTurn.id };
+    }
+    return { direct: status === 'idle' };
+  }
+
+  async sendSubagentMessage(threadId: string, text: string): Promise<unknown> {
+    const inputState = await this.readSubagentInput(threadId, true);
+    if (!inputState.direct) throw new Error('Direct input is unavailable for this subagent.');
+    const input = [{ type: 'text', text, text_elements: [] }];
+    // A raced turn completion is rejected by Codex; never retry as a new turn.
+    return inputState.activeTurnId
+      ? this.request('turn/steer', { threadId, input, expectedTurnId: inputState.activeTurnId })
+      : this.request('turn/start', { threadId, input });
+  }
+
   readAccount(): Promise<unknown> {
     return this.request('account/read', {});
   }
@@ -230,9 +269,10 @@ export class CodexAppServerManager extends EventEmitter {
     if (message.method === 'thread/started') {
       const thread = asRecord(params.thread);
       const threadId = typeof thread.id === 'string' ? thread.id : typeof params.threadId === 'string' ? params.threadId : undefined;
-      if (threadId) this.sessionState = { ...this.sessionState, state: 'idle', threadId };
+      if (threadId && (!this.sessionState.threadId || threadId === this.sessionState.threadId)) this.sessionState = { ...this.sessionState, state: 'idle', threadId };
       return;
     }
+    if (typeof params.threadId === 'string' && params.threadId !== this.sessionState.threadId) return;
     if (message.method === 'turn/started') {
       const turn = asRecord(params.turn);
       const activeTurnId = typeof turn.id === 'string' ? turn.id : typeof params.turnId === 'string' ? params.turnId : undefined;

--- a/src/lib/overdeck/__tests__/conversation-subagent-input.test.ts
+++ b/src/lib/overdeck/__tests__/conversation-subagent-input.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+const mocks = vi.hoisted(() => ({ getConversationByName: vi.fn(), postCodexAppServerOp: vi.fn(), resolveCodexSubagentTranscript: vi.fn() }));
+vi.mock('../conversations.js', () => ({ getConversationByName: mocks.getConversationByName }));
+vi.mock('../conversation-delivery.js', () => ({ postCodexAppServerOp: mocks.postCodexAppServerOp }));
+vi.mock('../../../dashboard/server/services/conversation/codex-subagents.js', () => ({ resolveCodexSubagentTranscript: mocks.resolveCodexSubagentTranscript }));
+import { conversationSubagentInput } from '../conversation-subagent-input.js';
+const deps = { resolveSessionFile: vi.fn(async () => '/parent.jsonl') };
+
+describe('conversation child input', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getConversationByName.mockReturnValue({ harness: 'codex', status: 'active', tmuxSession: 'conv-parent' });
+    mocks.resolveCodexSubagentTranscript.mockResolvedValue('/child.jsonl');
+    mocks.postCodexAppServerOp.mockResolvedValue({ direct: true });
+  });
+  it('probes the parent host without sending input', async () => {
+    expect(await conversationSubagentInput('parent', 'child', deps)).toEqual({ body: { direct: true } });
+    expect(mocks.postCodexAppServerOp).toHaveBeenCalledWith('conv-parent', { op: 'subagent-input', threadId: 'child' });
+  });
+  it('sends unchanged child text to only the direct host operation', async () => {
+    await conversationSubagentInput('parent', 'child', deps, { message: '/pan close is literal child input' });
+    expect(mocks.postCodexAppServerOp).toHaveBeenCalledWith('conv-parent', { op: 'subagent-message', threadId: 'child', content: '/pan close is literal child input' });
+  });
+  it('rejects unrelated children before calling the host', async () => {
+    mocks.resolveCodexSubagentTranscript.mockResolvedValue(null);
+    expect((await conversationSubagentInput('parent', 'outsider', deps, { message: 'hello' })).status).toBe(404);
+    expect(mocks.postCodexAppServerOp).not.toHaveBeenCalled();
+  });
+  it.each(['claude-code', 'pi'])('does not offer a composer or relay for %s', async harness => {
+    mocks.getConversationByName.mockReturnValue({ harness, status: 'active' });
+    expect((await conversationSubagentInput('parent', 'child', deps)).body).toMatchObject({ direct: false });
+    expect((await conversationSubagentInput('parent', 'child', deps, { message: 'hello' })).status).toBe(409);
+    expect(mocks.postCodexAppServerOp).not.toHaveBeenCalled();
+  });
+  it('fails closed for old hosts and never retries an uncertain send', async () => {
+    mocks.postCodexAppServerOp.mockRejectedValue(new Error('socket unavailable'));
+    expect((await conversationSubagentInput('parent', 'child', deps)).body).toMatchObject({ direct: false });
+    expect((await conversationSubagentInput('parent', 'child', deps, { message: 'hello' })).status).toBe(409);
+    expect(mocks.postCodexAppServerOp).toHaveBeenCalledTimes(2);
+  });
+  it('rejects ended sessions and invalid input', async () => {
+    expect((await conversationSubagentInput('parent', '../child', deps)).status).toBe(400);
+    expect((await conversationSubagentInput('parent', 'child', deps, { message: ' ' })).status).toBe(400);
+    mocks.getConversationByName.mockReturnValue({ harness: 'codex', status: 'ended' });
+    expect((await conversationSubagentInput('parent', 'child', deps, { message: 'hello' })).status).toBe(409);
+    expect(mocks.postCodexAppServerOp).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/overdeck/conversation-delivery.ts
+++ b/src/lib/overdeck/conversation-delivery.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { existsSync, readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { request as httpRequest } from 'node:http';
 import { join } from 'node:path';
 
@@ -528,12 +529,12 @@ function formatAppServerApprovalQuestion(request: CodexAppServerPendingRequest):
   return `Codex requests approval for ${request.method}`;
 }
 
-async function postCodexAppServerOp<T = Record<string, unknown>>(tmuxSession: string, body: Record<string, unknown>, transport: 'appserver' | 'acp' = 'appserver'): Promise<T> {
+export async function postCodexAppServerOp<T = Record<string, unknown>>(tmuxSession: string, body: Record<string, unknown>, transport: 'appserver' | 'acp' = 'appserver'): Promise<T> {
   const socketPath = join(getOverdeckHome(), 'sockets', `${transport}-${tmuxSession}.sock`);
   const tokenPath = join(getOverdeckHome(), 'agents', tmuxSession, `${transport}-token`);
   if (!existsSync(socketPath)) throw new Error(`app-server socket missing for ${tmuxSession}`);
   if (!existsSync(tokenPath)) throw new Error(`app-server token missing for ${tmuxSession}`);
-  const token = readFileSync(tokenPath, 'utf-8').trim();
+  const token = (await readFile(tokenPath, 'utf-8')).trim();
   if (!token) throw new Error(`app-server token missing for ${tmuxSession}`);
   const payload = JSON.stringify(body);
   return new Promise<T>((resolve, reject) => {

--- a/src/lib/overdeck/conversation-subagent-input.ts
+++ b/src/lib/overdeck/conversation-subagent-input.ts
@@ -1,0 +1,41 @@
+/** Direct child input only; no parent relay, terminal fallback, or thread resume. */
+import { getConversationByName } from './conversations.js';
+import { postCodexAppServerOp } from './conversation-delivery.js';
+import { resolveCodexSubagentTranscript } from '../../dashboard/server/services/conversation/codex-subagents.js';
+import type { ConversationReadDependencies, ConversationReadResult } from './conversation-reads.js';
+
+export async function conversationSubagentInput(
+  name: string,
+  agentId: string,
+  deps: Pick<ConversationReadDependencies, 'resolveSessionFile'>,
+  body?: Record<string, unknown>,
+): Promise<ConversationReadResult> {
+  const conversation = getConversationByName(name);
+  if (!conversation) return { status: 404, body: { error: 'Conversation not found' } };
+  if (!agentId || !/^[a-zA-Z0-9_-]{1,128}$/.test(agentId)) {
+    return { status: 400, body: { error: 'Invalid subagent id' } };
+  }
+  const unavailable = { status: body ? 409 : 200, body: { direct: false, error: 'Direct input is unavailable for this subagent.' } };
+  if (conversation.harness !== 'codex' || conversation.status === 'ended' || conversation.endedAt) return unavailable;
+  const parentFile = await deps.resolveSessionFile(conversation);
+  if (!parentFile || !await resolveCodexSubagentTranscript(parentFile, agentId)) {
+    return { status: 404, body: { error: 'Subagent does not belong to this conversation' } };
+  }
+  if (body && (typeof body.message !== 'string' || !body.message.trim() || body.message.length > 50_000)) {
+    return { status: 400, body: { error: 'A message of at most 50000 characters is required' } };
+  }
+  try {
+    const response = await postCodexAppServerOp(conversation.tmuxSession, {
+      op: body ? 'subagent-message' : 'subagent-input',
+      threadId: agentId,
+      ...(body ? { content: body.message } : {}),
+    });
+    return { body: response };
+  } catch {
+    // A capability probe is fail-closed. A send failure is never retried or
+    // reported as successful: the UI retains the draft for the operator.
+    return body
+      ? { status: 409, body: { error: 'Could not confirm delivery to this subagent. Check its transcript before retrying.' } }
+      : unavailable;
+  }
+}

--- a/tests/unit/dashboard/server/routes/conversations-no-loss.test.ts
+++ b/tests/unit/dashboard/server/routes/conversations-no-loss.test.ts
@@ -17,6 +17,7 @@ const CONVERSATIONS_ROUTE_FILE = join(
 
 const CONVERSATION_ROUTE_SURFACE_FILES = [
   CONVERSATIONS_ROUTE_FILE,
+  join(WORKSPACE_ROOT, 'src', 'dashboard', 'server', 'routes', 'conversation-subagent-input.ts'),
   join(WORKSPACE_ROOT, 'src', 'lib', 'overdeck', 'conversation-archive.ts'),
   join(WORKSPACE_ROOT, 'src', 'lib', 'overdeck', 'conversation-delivery.ts'),
   join(WORKSPACE_ROOT, 'src', 'lib', 'overdeck', 'conversation-diffs.ts'),
@@ -27,6 +28,8 @@ const CONVERSATION_ROUTE_SURFACE_FILES = [
 ] as const;
 
 const EXPECTED_CONVERSATION_ROUTES = [
+  'GET /api/conversations/:name/subagents/:agentId/input',
+  'POST /api/conversations/:name/subagents/:agentId/input',
   'GET /api/conversations',
   'GET /api/conversations/pending-input',
   'GET /api/conversations/archived',
@@ -95,7 +98,7 @@ describe('PAN-2145 conversations route no-loss audit', () => {
     expect(source).toMatch(/export\s+const\s+conversationsRouteLayer\s*=/);
   });
 
-  it('keeps all 38 conversationsRouteLayer method/path registrations', () => {
+  it('keeps all 40 conversationsRouteLayer method/path registrations', () => {
     const liveRoutes = enumerateConversationRoutes();
     const expectedRoutes = new Set(EXPECTED_CONVERSATION_ROUTES);
 
@@ -118,6 +121,6 @@ describe('PAN-2145 conversations route no-loss audit', () => {
       ...unexpected.map((route) => `  unexpected: ${route}`),
     ].join('\n')).toEqual([]);
 
-    expect(liveRoutes.size).toBe(38);
+    expect(liveRoutes.size).toBe(40);
   });
 });

--- a/tests/unit/lib/overdeck/no-loss-matrix.ts
+++ b/tests/unit/lib/overdeck/no-loss-matrix.ts
@@ -173,6 +173,8 @@ export const NO_LOSS_MATRIX: MatrixEntry[] = [
   { surface: 'POST /api/conversations/:name/stop',                       kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.stop' },
   { surface: 'POST /api/conversations/:name/resume',                     kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.resume' },
   { surface: 'POST /api/conversations/:name/switch-model',               kind: 'http', disposition: 'WRITE',       door: 'ConversationWriter.setHarness/setModel before first session only' },
+  { surface: 'GET /api/conversations/:name/subagents/:agentId/input', kind: 'http', disposition: 'READ', door: 'conversationSubagentInput: validate parent membership and read live direct-input capability' },
+  { surface: 'POST /api/conversations/:name/subagents/:agentId/input', kind: 'http', disposition: 'WRITE', door: 'conversationSubagentInput: direct validated child delivery through the persistent Codex host' },
   { surface: 'GET /api/conversations/:name/messages',                    kind: 'http', disposition: 'READ',        door: 'TranscriptsResolver.parse' },
   { surface: 'GET /api/conversations/:name/message-locator',             kind: 'http', disposition: 'READ',        door: 'TranscriptsResolver.resolveFile' },
   { surface: 'POST /api/conversations/:name/upload-image',               kind: 'http', disposition: 'RELOCATE',    door: 'ConversationRuntime.stageAttachment' },


### PR DESCRIPTION
Subagent views now show the shared “Working for …” activity indicator and a bottom composer only when direct child delivery is available. A running Codex child no longer loses its indicator because the transcript snapshot reports `streaming: false`.

The composer requires a loaded child in the same persistent Codex app-server process. Both the conversation resolver and host validate parent membership; active turns use `turn/steer` with the expected turn ID, and idle children use `turn/start` with the child ID. Child events cannot replace the primary thread, turn, pane output, or activity. Drafts remain separate per child, and failed or uncertain sends retain their text without automatic retries.

Per the operator's explicit decision, unsupported sessions show no composer. Claude Code PTY sessions, Codex TUI sessions, old hosts, and unloaded children remain read-only. There is no parent relay, new replacement thread, or automatic child resume. Existing conversations must restart their host to acquire the new operation. User and developer docs describe this limitation.

Validation:
- Full `npm test`: 14,135 backend tests and 64 required frontend tests passed; 51 backend tests skipped by existing configuration.
- Focused frontend: 40 tests passed, including composer, activity timer, and existing prompt editor behavior.
- Final host isolation tests: 25 passed.
- Typecheck, all lint stages, build, and route/no-loss audits passed.
- Playwright preview: rendered and inspected the composer and working timer; verified child recipient, clear-on-ack, isolated persistent drafts, completion state, and no Claude composer. Browser transport used controlled responses; no messages were sent into unrelated live agent threads.
- Isolated Node dashboard boot returned healthy; GET and POST child-input routes returned the expected missing-conversation 404.

Tracks #3787. Leave the ticket open until merge and deployment satisfy close-out.
