### PR TITLE
PAN-3795

### DIFF
--- a/src/cli/commands/reopen.ts
+++ b/src/cli/commands/reopen.ts
@@ -14,7 +14,7 @@ import { resolveProjectFromIssueSync } from '../../lib/projects.js';
 import { resolveBareNumericIdSync } from '../../lib/issue-id.js';
 import { resolveTrackerTypeSync, isGitHubIssueSync, resolveGitHubIssueSync } from '../../lib/tracker-utils.js';
 
-interface ReopenOptions {
+export interface ReopenOptions {
   json?: boolean;
   force?: boolean;
   reason?: string;
@@ -560,8 +560,11 @@ async function reopenLinearIssueCommand(id: string, options: ReopenOptions): Pro
  * Shared workspace state reset logic for both GitHub and Linear reopen paths.
  * Uses resolveProjectFromIssue internally so it works for any tracker.
  */
-async function resetWorkspaceState(id: string, options: ReopenOptions): Promise<void> {
-  const workspacePath = findLocalWorkspace(id);
+export async function resetWorkspaceState(
+  id: string,
+  options: ReopenOptions,
+  workspacePath = findLocalWorkspace(id),
+): Promise<void> {
   let trackerContext: string | undefined;
 
   if (workspacePath) {
@@ -571,41 +574,39 @@ async function resetWorkspaceState(id: string, options: ReopenOptions): Promise<
     } catch {
       // Non-fatal: tracker context is best-effort
     }
+  }
 
-    const resetSpinner = ora('Resetting workspace state...').start();
-    const result = await Effect.runPromise(reopenWorkspaceState(id, workspacePath, {
-      reason: options.reason,
-      trackerContext,
-    }));
-    resetSpinner.succeed('Workspace state reset');
+  const resetSpinner = ora('Resetting canonical pipeline state...').start();
+  const result = await Effect.runPromise(reopenWorkspaceState(id, workspacePath, {
+    reason: options.reason,
+    trackerContext,
+  }));
+  resetSpinner.succeed('Canonical pipeline state reset');
 
-    console.log('');
-    console.log(chalk.bold('Reset summary:'));
-    if (result.previousReviewStatus) {
-      console.log(`  Review: ${chalk.yellow(result.previousReviewStatus)} → ${chalk.green('pending')}`);
-    }
-    if (result.previousTestStatus) {
-      console.log(`  Test:   ${chalk.yellow(result.previousTestStatus)} → ${chalk.green('pending')}`);
-    }
-    if (result.previousMergeStatus) {
-      console.log(`  Merge:  ${chalk.yellow(result.previousMergeStatus)} → ${chalk.green('pending')}`);
-    }
+  console.log('');
+  console.log(chalk.bold('Reset summary:'));
+  if (result.previousReviewStatus) {
+    console.log(`  Review: ${chalk.yellow(result.previousReviewStatus)} → ${chalk.green('pending')}`);
+  }
+  if (result.previousTestStatus) {
+    console.log(`  Test:   ${chalk.yellow(result.previousTestStatus)} → ${chalk.green('pending')}`);
+  }
+  if (result.previousMergeStatus) {
+    console.log(`  Merge:  ${chalk.yellow(result.previousMergeStatus)} → ${chalk.green('pending')}`);
+  }
 
-    const queueEntries = Object.entries(result.queueItemsRemoved);
-    if (queueEntries.length > 0) {
-      console.log(`  Queue items removed:`);
-      for (const [specialist, count] of queueEntries) {
-        console.log(`    ${specialist}: ${count} item(s)`);
-      }
+  const queueEntries = Object.entries(result.queueItemsRemoved);
+  if (queueEntries.length > 0) {
+    console.log(`  Queue items removed:`);
+    for (const [specialist, count] of queueEntries) {
+      console.log(`    ${specialist}: ${count} item(s)`);
     }
+  }
 
-    if (result.continueFileUpdated) {
-      console.log(`  Continue file updated with reopen breadcrumb`);
-    }
+  if (result.continueFileUpdated) {
+    console.log(`  Continue file updated with reopen breadcrumb`);
   } else {
-    console.log('');
-    console.log(chalk.yellow(`  No local workspace found for ${id} — skipping workspace state reset`));
-    console.log(chalk.dim('  Specialist states were not modified.'));
+    console.log(chalk.dim('  Workspace breadcrumb skipped: no local workspace or xBRIEF was available.'));
   }
 }
 

--- a/src/lib/reopen.ts
+++ b/src/lib/reopen.ts
@@ -31,10 +31,12 @@ export interface ReopenResult {
 export interface ReopenOptions {
   reason?: string;
   trackerContext?: string;
-}async function reopenWorkspaceStatePromise(
+}
+
+async function reopenWorkspaceStatePromise(
   issueId: string,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  workspacePath: string,
+  workspacePath: string | null,
   options: ReopenOptions = {}
 ): Promise<ReopenResult> {
   const result: ReopenResult = {
@@ -59,6 +61,15 @@ export interface ReopenOptions {
     result.previousMergeStatus = existing.mergeStatus ?? null;
   }
 
+  const resolved = resolveProjectFromIssueSync(issueId);
+  if (resolved) {
+    // Clear the terminal close-out marker before publishing the fresh status.
+    // Otherwise this record write can become newer than the reset and restore
+    // its old verdicts during the next canonical read.
+    const project = getProjectSync(resolved.projectKey);
+    if (project) clearRecordPipelineClosedOutSync(project, issueId.toUpperCase());
+  }
+
   setReviewStatusSync(issueId, {
     reviewStatus: 'pending',
     testStatus: 'pending',
@@ -66,29 +77,41 @@ export interface ReopenOptions {
     mergeStatus: 'pending',
     reviewNotes: `Reopened${options.reason ? `: ${options.reason}` : ''}`,
     testNotes: undefined,
+    verificationNotes: undefined,
+    verificationCycleCount: 0,
     mergeNotes: undefined,
     readyForMerge: false,
     prUrl: existing?.prUrl,
     autoRequeueCount: 0,
+    reviewRetryCount: 0,
+    testRetryCount: 0,
+    mergeRetryCount: 0,
+    recoveryStartedAt: undefined,
+    reviewRequestedAt: undefined,
+    reviewSpawnedAt: undefined,
+    conflictResolutionDispatchedAt: undefined,
+    blockerReasons: undefined,
+    mergeStep: undefined,
+    retiredAt: undefined,
     // PAN-653: clear stuck state so Deacon resumes processing this issue.
-    // reviewedAtCommit is cleared so the next approve cycle records the new commit SHA.
     stuck: undefined,
     stuckReason: undefined,
     stuckAt: undefined,
     stuckDetails: undefined,
+    // Start a new evidence cycle while retaining status history and prior
+    // strike-landing attempts.
     reviewedAtCommit: undefined,
+    lastVerifiedCommit: undefined,
+    strikeReadyHead: undefined,
+    strikeReadyAt: undefined,
+    strikeLandingState: undefined,
+    strikeRecoveryCount: 0,
+    strikeTransportRetryCount: undefined,
+    strikeNextAttemptAt: undefined,
   });
   result.specialistStatesReset = true;
 
   // 2. Append a reopen breadcrumb to the scope xBRIEF's continue file.
-  const resolved = resolveProjectFromIssueSync(issueId);
-  if (resolved) {
-    // Clear the terminal close-out marker: status writes deliberately preserve
-    // closedOut (records.ts), so without this a reopened issue stays invisible
-    // to review dispatch and the dashboard forever (MIN-850, 2026-07-24).
-    const project = getProjectSync(resolved.projectKey);
-    if (project) clearRecordPipelineClosedOutSync(project, issueId.toUpperCase());
-  }
   if (resolved) {
     try {
       const noteParts: string[] = [`Reopened on ${new Date().toISOString().slice(0, 10)}`];
@@ -131,7 +154,7 @@ export class ReopenError extends Data.TaggedError('ReopenError')<{
 /** Effect variant of `reopenWorkspaceState`. */
 export const reopenWorkspaceState = (
   issueId: string,
-  workspacePath: string,
+  workspacePath: string | null,
   options: ReopenOptions = {},
 ): Effect.Effect<ReopenResult, ReopenError> =>
   Effect.tryPromise({
@@ -143,4 +166,3 @@ export const reopenWorkspaceState = (
         cause,
       }),
   });
-

--- a/tests/cli/commands/work/reopen-reset.test.ts
+++ b/tests/cli/commands/work/reopen-reset.test.ts
@@ -1,0 +1,70 @@
+import { Effect } from 'effect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGetTrackerContext, mockReopenWorkspaceState, mockSpinnerSucceed } = vi.hoisted(() => ({
+  mockGetTrackerContext: vi.fn(),
+  mockReopenWorkspaceState: vi.fn(),
+  mockSpinnerSucceed: vi.fn(),
+}));
+
+vi.mock('ora', () => ({
+  default: () => ({
+    start: () => ({ succeed: mockSpinnerSucceed }),
+  }),
+}));
+
+vi.mock('../../../../src/lib/reopen.js', () => ({
+  reopenWorkspaceState: (...args: unknown[]) => mockReopenWorkspaceState(...args),
+}));
+
+vi.mock('../../../../src/lib/cloister/work-agent-prompt.js', () => ({
+  getTrackerContext: (...args: unknown[]) => mockGetTrackerContext(...args),
+}));
+
+import { resetWorkspaceState } from '../../../../src/cli/commands/reopen.js';
+
+describe('resetWorkspaceState', () => {
+  beforeEach(() => {
+    mockReopenWorkspaceState.mockReset();
+    mockSpinnerSucceed.mockReset();
+    mockGetTrackerContext.mockReset();
+    mockGetTrackerContext.mockResolvedValue('tracker context');
+    mockReopenWorkspaceState.mockReturnValue(Effect.succeed({
+      specialistStatesReset: true,
+      previousReviewStatus: 'passed',
+      previousTestStatus: 'passed',
+      previousMergeStatus: 'merged',
+      queueItemsRemoved: {},
+      continueFileUpdated: false,
+    }));
+  });
+
+  it('runs the canonical pipeline reset when no local feature workspace exists', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await resetWorkspaceState('PAN-3795', { force: true }, null);
+
+    expect(mockReopenWorkspaceState).toHaveBeenCalledWith('PAN-3795', null, {
+      reason: undefined,
+      trackerContext: undefined,
+    });
+    expect(mockSpinnerSucceed).toHaveBeenCalledWith('Canonical pipeline state reset');
+    const output = log.mock.calls.flat().join('\n');
+    expect(output).toContain('Workspace breadcrumb skipped');
+    expect(output).not.toContain('Specialist states were not modified');
+    log.mockRestore();
+  });
+
+  it('keeps tracker context and the breadcrumb path for a local feature workspace', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await resetWorkspaceState('PAN-3795', { reason: 'retry' }, '/repo/workspaces/feature-pan-3795');
+
+    expect(mockGetTrackerContext).toHaveBeenCalledWith('PAN-3795', '/repo/workspaces/feature-pan-3795');
+    expect(mockReopenWorkspaceState).toHaveBeenCalledWith('PAN-3795', '/repo/workspaces/feature-pan-3795', {
+      reason: 'retry',
+      trackerContext: 'tracker context',
+    });
+    log.mockRestore();
+  });
+});

--- a/tests/lib/reopen.test.ts
+++ b/tests/lib/reopen.test.ts
@@ -112,6 +112,9 @@ afterEach(() => {
 // ── Import under test (after mocks) ─────────────────────────────────────────
 
 import { reopenWorkspaceState } from '../../src/lib/reopen.js';
+import { strikeReadyCommand } from '../../src/cli/commands/strike-ready.js';
+import { patrolStrikeLandings, type StrikeLandingDeps } from '../../src/lib/cloister/deacon-strike-landing.js';
+import { getReviewStatusSync, loadReviewStatuses, setReviewStatusSync } from '../../src/lib/review-status.js';
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
@@ -428,6 +431,125 @@ describe('reopenWorkspaceState', () => {
       expect(updated.pipeline.reopenedAt).toBeTypeOf('string');
 
       rmSync(wsDir, { recursive: true, force: true });
+      rmSync(projectRoot, { recursive: true, force: true });
+    });
+
+    it('reopens a merged strike without a feature workspace and lets Deacon claim its new ready head', async () => {
+      const projectRoot = mkdtempSync(join(tmpdir(), 'pan-reopen-project-'));
+      seedRecord(projectRoot, 'PAN-905');
+      projectStub = { projectPath: projectRoot, projectKey: 'fixture-project' };
+
+      seedStatus({
+        'PAN-905': {
+          reviewStatus: 'passed',
+          testStatus: 'passed',
+          verificationStatus: 'passed',
+          mergeStatus: 'merged',
+          readyForMerge: false,
+        },
+      });
+      const priorHead = 'a'.repeat(40);
+      const newHead = 'b'.repeat(40);
+      const priorAttempts = JSON.stringify([{
+        timestamp: '2026-08-01T00:00:00.000Z',
+        strikeHead: priorHead,
+        mainHead: 'c'.repeat(40),
+        outcome: 'merged',
+        detail: 'Prior strike landed',
+      }]);
+      const recordPath = join(projectRoot, '.pan', 'records', 'pan-905.json');
+      const record = JSON.parse(readFileSync(recordPath, 'utf-8'));
+      record.pipeline = {
+        issueId: 'PAN-905',
+        reviewStatus: 'passed',
+        testStatus: 'passed',
+        verificationStatus: 'passed',
+        mergeStatus: 'merged',
+        readyForMerge: false,
+        closedOut: true,
+        closedOutAt: '2026-08-01T00:00:00.000Z',
+        strikeReadyHead: priorHead,
+        strikeReadyAt: '2026-08-01T00:00:00.000Z',
+        strikeLandingState: 'landed',
+        strikeRecoveryCount: 2,
+        strikeTransportRetryCount: 3,
+        strikeNextAttemptAt: '2026-08-02T00:00:00.000Z',
+        strikeLandingAttempts: JSON.parse(priorAttempts),
+        updatedAt: '2026-08-01T00:00:00.000Z',
+      };
+      writeFileSync(recordPath, JSON.stringify(record), 'utf-8');
+      odb.raw().prepare(`
+        UPDATE review_status
+        SET strike_ready_head = ?, strike_ready_at = ?, strike_landing_state = 'landed',
+            strike_recovery_count = 2, strike_transport_retry_count = 3,
+            strike_next_attempt_at = ?, strike_landing_attempts = ?
+        WHERE issue_id = 'PAN-905'
+      `).run(priorHead, Date.parse('2026-08-01T00:00:00.000Z'), Date.parse('2026-08-02T00:00:00.000Z'), priorAttempts);
+
+      const result = await Effect.runPromise(reopenWorkspaceState('PAN-905', null));
+      expect(result.specialistStatesReset).toBe(true);
+      expect(existsSync(join(projectRoot, 'workspaces', 'feature-pan-905'))).toBe(false);
+
+      const reopened = getReviewStatusSync('PAN-905')!;
+      expect(reopened).toMatchObject({
+        reviewStatus: 'pending',
+        testStatus: 'pending',
+        verificationStatus: 'pending',
+        mergeStatus: 'pending',
+        readyForMerge: false,
+        strikeRecoveryCount: 0,
+      });
+      expect(reopened.strikeReadyHead).toBeUndefined();
+      expect(reopened.strikeReadyAt).toBeUndefined();
+      expect(reopened.strikeLandingState).toBeUndefined();
+      expect(reopened.strikeTransportRetryCount).toBeUndefined();
+      expect(reopened.strikeNextAttemptAt).toBeUndefined();
+      expect(reopened.strikeLandingAttempts).toEqual(JSON.parse(priorAttempts));
+
+      const strikeWorkspace = join(projectRoot, 'workspaces', 'feature-pan-905-strike');
+      const git = vi.fn(async (args: string[]) => {
+        const command = args.join(' ');
+        if (command === 'rev-parse --show-toplevel') return strikeWorkspace;
+        if (command === 'branch --show-current') return 'strike/pan-905';
+        if (command === 'worktree list --porcelain') {
+          return `worktree ${strikeWorkspace}\nHEAD ${newHead}\nbranch refs/heads/strike/pan-905\n`;
+        }
+        if (command === 'status --porcelain' || command === 'fetch origin strike/pan-905') return '';
+        if (command === 'rev-parse HEAD' || command === 'rev-parse origin/strike/pan-905') return newHead;
+        throw new Error(`Unexpected git invocation: ${command}`);
+      });
+      await strikeReadyCommand('PAN-905', {
+        cwd: strikeWorkspace,
+        resolveProject: () => ({ projectPath: projectRoot, projectKey: 'fixture-project' }) as never,
+        git,
+      });
+
+      const scheduled: Promise<void>[] = [];
+      const mergeIssue = vi.fn().mockResolvedValue({ success: true, mergeStatus: 'queued' });
+      const actions = await patrolStrikeLandings({
+        loadStatuses: () => loadReviewStatuses(),
+        getStatus: getReviewStatusSync,
+        setStatus: setReviewStatusSync,
+        resolveProject: () => ({ projectPath: projectRoot, projectKey: 'fixture-project' }) as never,
+        mergeIssue,
+        getMainHead: vi.fn().mockResolvedValue('c'.repeat(40)),
+        deliverRecovery: vi.fn(),
+        writeFeedback: vi.fn(),
+        needsYou: vi.fn(),
+        now: () => '2026-08-03T00:00:00.000Z',
+        schedule: (_key, work) => scheduled.push(work()),
+        isScheduled: () => false,
+        isPersistentlyOwned: () => false,
+        listProjects: vi.fn().mockResolvedValue([]),
+        git: vi.fn(),
+        isStrikeAgentAlive: vi.fn().mockResolvedValue(false),
+      } satisfies StrikeLandingDeps);
+      await Promise.all(scheduled);
+
+      expect(actions).toEqual([`[strike-landing] claimed PAN-905 at ${newHead}`]);
+      expect(mergeIssue).toHaveBeenCalledWith('PAN-905', expect.objectContaining({ markerHead: newHead }));
+      expect(getReviewStatusSync('PAN-905')?.strikeLandingState).toBe('landing');
+
       rmSync(projectRoot, { recursive: true, force: true });
     });
 

--- a/tests/unit/lib/head-anchor-write-sites.test.ts
+++ b/tests/unit/lib/head-anchor-write-sites.test.ts
@@ -76,6 +76,7 @@ const ALLOWED_WRITE_SITES: AllowedWriteSite[] = [
   allow('src/lib/reconstruct/reconstruct-cache.ts', 'lastVerifiedCommit', 'lastVerifiedCommit: pipeline.lastVerifiedCommit', 'Cache reconstruction from durable state.'),
   allow('src/lib/reconstruct/reconstruct-cache.ts', 'roleRunHead', 'roleRunHead: agent.roleRunHead ?? undefined', 'Cache reconstruction from agent storage.'),
   allow('src/lib/reopen.ts', 'reviewedAtCommit', 'reviewedAtCommit: undefined', 'Explicit reopen clear.'),
+  allow('src/lib/reopen.ts', 'lastVerifiedCommit', 'lastVerifiedCommit: undefined', 'Explicit reopen clear starts a fresh verification cycle.'),
   allow('src/lib/review-status.ts', 'reviewedAtCommit', 'reviewedAtCommit: undefined', 'Explicit work-start clear.'),
   allow('src/lib/review-status.ts', 'reviewedAtCommit', 'reviewedAtCommit: status.reviewedAtCommit as HeadAnchor | undefined', 'Verdict-preservation adapter supplies a branded review anchor.'),
   allow('src/lib/review-status.ts', 'reviewedAtCommit', 'reviewedAtCommit: anchor', 'Verdict-preservation adapter advances a proven-benign review anchor.'),


### PR DESCRIPTION
**Issue:** #3795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reopening an item now works even when no local workspace is available.
  - Workspace state is fully reset, including verification, recovery, merge, and retry information.
  - Reopen status messages now clearly indicate whether the continue-file breadcrumb was updated or skipped.
  - Reopened work can return to the ready queue and proceed through the merge workflow as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->