### PR TITLE
PAN-3492

### DIFF
--- a/src/lib/cloister/verification-worker-supervisor.ts
+++ b/src/lib/cloister/verification-worker-supervisor.ts
@@ -20,6 +20,8 @@ export type WorkerState = {
 
 const POLL_MS = 250;
 const MAX_RUN_MS = 65 * 60 * 1000;
+const WORKER_EXIT_POLL_MS = 50;
+const WORKER_EXIT_GRACE_MS = 1_000;
 
 function safeIssueId(issueId: string): string {
   return issueId.toLowerCase().replace(/[^a-z0-9-]/g, '-');
@@ -46,18 +48,23 @@ function isProcessAlive(pid: number): boolean {
  * Kill an expired worker and its gate children. The worker is spawned
  * detached, so it leads its own process group — signal the group first so a
  * mid-gate `npm`/`bun` child dies with it, falling back to the bare pid.
- * Best-effort and async; callers never block on the outcome.
+ * Wait for the worker to exit before returning so timeout recovery cannot
+ * overlap a fresh verification run with the expired worker.
  */
-async function killWorkerProcessGroup(pid: number): Promise<void> {
+async function killWorkerProcessGroup(pid: number): Promise<boolean> {
   for (const signal of ['SIGTERM', 'SIGKILL'] as const) {
     try {
       process.kill(-pid, signal);
     } catch {
       try { process.kill(pid, signal); } catch { /* already gone */ }
     }
-    if (!isProcessAlive(pid)) return;
-    await new Promise<void>((resolve) => setTimeout(resolve, 1_000));
+    const deadline = Date.now() + WORKER_EXIT_GRACE_MS;
+    while (isProcessAlive(pid) && Date.now() < deadline) {
+      await new Promise<void>((resolve) => setTimeout(resolve, WORKER_EXIT_POLL_MS));
+    }
+    if (!isProcessAlive(pid)) return true;
   }
+  return false;
 }
 
 export function readVerificationWorkerState(issueId: string): WorkerState | null {
@@ -99,7 +106,7 @@ function writeJsonAtomic(path: string, value: unknown): void {
 }
 
 export function verificationWorkerDeadline(state: WorkerState): number | null {
-  if (!state.admittedAt) return null;
+  if (state.phase !== 'running' || !state.admittedAt) return null;
   const admittedAt = Date.parse(state.admittedAt);
   return Number.isFinite(admittedAt) ? admittedAt + MAX_RUN_MS : null;
 }
@@ -118,7 +125,7 @@ export function markVerificationWorkerAdmissionPhase(
   writeJsonAtomic(statePath(issueId), {
     ...state,
     phase: update.phase,
-    admittedAt: state.admittedAt ?? update.admittedAt ?? null,
+    admittedAt: update.phase === 'running' ? update.admittedAt ?? null : null,
     currentGate: update.gateName,
     currentAttempt: update.attempt,
   });
@@ -139,7 +146,7 @@ async function waitForResult(state: WorkerState): Promise<VerificationRunnerOutc
       // Leaving it alive stranded PAN-3668 on 2026-08-13: every later attempt
       // re-joined the zombie registration and instantly re-failed on the same
       // deadline, and no fresh worker ever started.
-      void killWorkerProcessGroup(state.pid);
+      await killWorkerProcessGroup(state.pid);
       return { outcome: 'error', message: `Verification worker ${state.pid} exceeded ${MAX_RUN_MS}ms after CPU admission` };
     }
     await new Promise<void>((resolve) => setTimeout(resolve, POLL_MS));
@@ -164,7 +171,12 @@ export async function runSupervisedVerification(
       return waitForResult(existing);
     }
     console.warn(`[${logPrefix}] Verification worker ${existing.pid} for ${issueId} is past its deadline — killing it and starting fresh`);
-    await killWorkerProcessGroup(existing.pid);
+    if (!await killWorkerProcessGroup(existing.pid)) {
+      return {
+        outcome: 'error',
+        message: `Verification worker ${existing.pid} is past its deadline but still alive; refusing to start an overlapping worker`,
+      };
+    }
   }
 
   const dir = workerDir(issueId);

--- a/tests/unit/lib/cloister/verification-worker-supervisor.test.ts
+++ b/tests/unit/lib/cloister/verification-worker-supervisor.test.ts
@@ -63,7 +63,9 @@ describe('verification worker supervisor', () => {
       .toBe(Date.parse(admittedAt) + 65 * 60 * 1000);
   });
 
-  it('persists queued and running admission phases without resetting first admission', () => {
+  it('excludes every admission queue from the deadline across multiple gates', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-19T00:00:00.000Z'));
     const home = useFixture();
     const dir = join(home, 'verification-workers', 'pan-1');
     mkdirSync(dir, { recursive: true });
@@ -79,18 +81,37 @@ describe('verification worker supervisor', () => {
     }));
 
     markVerificationWorkerAdmissionPhase('PAN-1', {
-      phase: 'running', gateName: 'typecheck', attempt: 1, admittedAt: '2026-07-19T01:00:00.000Z',
+      phase: 'running', gateName: 'typecheck', attempt: 1, admittedAt: new Date().toISOString(),
     });
+    vi.advanceTimersByTime(60 * 60_000);
     markVerificationWorkerAdmissionPhase('PAN-1', {
       phase: 'queued', gateName: 'lint', attempt: 1,
     });
 
-    expect(readVerificationWorkerState('PAN-1')).toMatchObject({
+    let state = readVerificationWorkerState('PAN-1')!;
+    expect(state).toMatchObject({
       phase: 'queued',
-      admittedAt: '2026-07-19T01:00:00.000Z',
+      admittedAt: null,
       currentGate: 'lint',
       currentAttempt: 1,
     });
+    expect(verificationWorkerDeadline(state)).toBeNull();
+
+    vi.advanceTimersByTime(2 * 60 * 60_000);
+    markVerificationWorkerAdmissionPhase('PAN-1', {
+      phase: 'running', gateName: 'lint', attempt: 1, admittedAt: new Date().toISOString(),
+    });
+    state = readVerificationWorkerState('PAN-1')!;
+    expect(verificationWorkerDeadline(state)).toBe(Date.now() + 65 * 60_000);
+
+    vi.advanceTimersByTime(60 * 60_000);
+    markVerificationWorkerAdmissionPhase('PAN-1', {
+      phase: 'queued', gateName: 'test', attempt: 1,
+    });
+    vi.advanceTimersByTime(2 * 60 * 60_000);
+    state = readVerificationWorkerState('PAN-1')!;
+    expect(state).toMatchObject({ phase: 'queued', admittedAt: null, currentGate: 'test' });
+    expect(verificationWorkerDeadline(state)).toBeNull();
   });
 
   it('runs verification in a detached worker and returns its durable result', async () => {
@@ -228,32 +249,25 @@ describe('PAN-3674 follow-up: expired workers', () => {
   });
 
   it('kills the worker when the execution deadline fires mid-run', async () => {
-    const home = useFixture(5_000); // slow fixture: outlives the deadline trip
+    vi.useFakeTimers();
+    const home = useFixture(60_000); // slow fixture: outlives the deadline trip
     const pending = runSupervisedVerification('PAN-3675', '/tmp/workspace', { isRemote: false }, 'test');
 
-    // Wait for the worker to register, then age its admission past the budget.
+    // The supervisor registers the worker before its first polling delay. Age
+    // the active gate past its budget, then advance the polling and kill timers.
     const stateFile = join(home, 'verification-workers', 'pan-3675', 'state.json');
-    let pid = -1;
-    for (let i = 0; i < 100; i++) {
-      const s = readVerificationWorkerState('PAN-3675');
-      if (s) { pid = s.pid; break; }
-      await new Promise((r) => setTimeout(r, 25));
-    }
+    const pid = readVerificationWorkerState('PAN-3675')!.pid;
     expect(pid).toBeGreaterThan(0);
     const seeded = JSON.parse(readFileSync(stateFile, 'utf8'));
+    seeded.phase = 'running';
     seeded.admittedAt = new Date(Date.now() - 66 * 60_000).toISOString();
     writeFileSync(stateFile, JSON.stringify(seeded));
 
+    await vi.advanceTimersByTimeAsync(3_000);
     const outcome = await pending;
     expect(outcome.outcome).toBe('error');
     expect(outcome.outcome === 'error' ? outcome.message : '').toContain('exceeded');
-    // The kill ladder (TERM → 1s → KILL) is fire-and-forget behind the verdict —
-    // poll for death instead of racing it.
-    let dead = false;
-    for (let i = 0; i < 120 && !dead; i++) {
-      try { process.kill(pid, 0); } catch { dead = true; }
-      if (!dead) await new Promise((r) => setTimeout(r, 25));
-    }
-    expect(dead).toBe(true);
+    // Recovery cannot start while the expired worker remains live.
+    expect(() => process.kill(pid, 0)).toThrow();
   });
 });


### PR DESCRIPTION
**Issue:** #3492


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved verification worker recovery when a run exceeds its allowed time.
  - Prevented new verification runs from starting while an expired worker is still shutting down.
  - Improved deadline tracking so queued work does not retain an outdated running deadline.
  - Ensured expired workers are stopped before recovery proceeds, reducing the risk of overlapping verification runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->