### PR TITLE
PAN-3812

### DIFF
--- a/src/cli/commands/__tests__/restart-agent-gate.test.ts
+++ b/src/cli/commands/__tests__/restart-agent-gate.test.ts
@@ -261,21 +261,41 @@ describe('restartCommand agent deploy-window gate', () => {
     });
 
     it('--now approves and steps aside when another process already holds the restart lock', async () => {
+      process.env.OVERDECK_AGENT_ID = 'flywheel-orchestrator';
       mocks.readRestartLockHolder.mockReturnValue(Effect.succeed({
         pid: 4242,
         ts: Date.now(),
         caller: 'pan reload',
       }));
+      mocks.agentRestartBlockReason.mockResolvedValue('Restart refused by active deployment gate.');
       mocks.approveRestartGate.mockResolvedValue({ approved: true, pendingCount: 2 });
 
       await restartCommand({ dashboard: true, now: true });
 
+      expect(mocks.agentRestartBlockReason).not.toHaveBeenCalled();
       expect(mocks.approveRestartGate).toHaveBeenCalledTimes(1);
       expect(mocks.claimRestartGate).not.toHaveBeenCalled();
       expect(mocks.acquireRestartLock).not.toHaveBeenCalled();
       expect(mocks.restartDashboard).not.toHaveBeenCalled();
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('PID 4242 (pan reload)'));
       expect(process.exitCode).toBeUndefined();
+    });
+
+    it('keeps agent restart-window protection for --now when no reload handoff exists', async () => {
+      process.env.OVERDECK_AGENT_ID = 'flywheel-orchestrator';
+      mocks.agentRestartBlockReason.mockResolvedValue('Restart refused by active deployment gate.');
+
+      await restartCommand({ dashboard: true, now: true });
+
+      expect(mocks.agentRestartBlockReason).toHaveBeenCalledWith({
+        initiator: 'flywheel-orchestrator',
+        force: false,
+      });
+      expect(mocks.registerRestartGateRequest).not.toHaveBeenCalled();
+      expect(mocks.approveRestartGate).not.toHaveBeenCalled();
+      expect(mocks.acquireRestartLock).not.toHaveBeenCalled();
+      expect(mocks.restartDashboard).not.toHaveBeenCalled();
+      expect(process.exitCode).toBe(1);
     });
   });
 });

--- a/src/cli/commands/restart.ts
+++ b/src/cli/commands/restart.ts
@@ -456,9 +456,14 @@ export async function restartApproveCommand(): Promise<void> {
  * process performs the restart this command just approved, so starting a second
  * one here would restart the dashboard twice.
  */
-async function runRestartNowBypass(scope: 'dashboard' | 'full'): Promise<'restart' | 'handed-off'> {
+async function runRestartNowBypass(
+  scope: 'dashboard' | 'full',
+  options: { reloadHandoffOnly?: boolean } = {},
+): Promise<'restart' | 'handed-off' | 'no-handoff'> {
   const requesterId = restartGateRequesterId('restart');
   const lockHolder = await Effect.runPromise(readRestartLockHolder());
+  if (options.reloadHandoffOnly && lockHolder?.caller !== 'pan reload') return 'no-handoff';
+
   await registerRestartGateRequest({
     requesterId,
     kind: 'restart',
@@ -476,6 +481,8 @@ async function runRestartNowBypass(scope: 'dashboard' | 'full'): Promise<'restar
     );
     return 'handed-off';
   }
+
+  if (options.reloadHandoffOnly) return 'no-handoff';
 
   await claimRestartGate(requesterId);
   return 'restart';
@@ -563,6 +570,12 @@ export async function restartCommand(options: RestartOptions): Promise<void> {
   const lockInherited = process.env.OVERDECK_RESTART_LOCK_HELD === '1';
   const needsRestartLock = (scope === 'dashboard' || scope === 'full') && !lockInherited;
   const restartInitiator = process.env.OVERDECK_AGENT_ID;
+  if (needsRestartLock && restartInitiator && options.now) {
+    // An agent-owned `pan reload` already holds the lock while it waits at the
+    // approval gate. Let `--now` approve that request and step aside before the
+    // deploy-window guard mistakes the reload itself for a competing deploy.
+    if (await runRestartNowBypass(scope, { reloadHandoffOnly: true }) === 'handed-off') return;
+  }
   if (needsRestartLock && restartInitiator) {
     const restartBlock = await agentRestartBlockReason({
       initiator: restartInitiator,


### PR DESCRIPTION
**Issue:** #3812


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `--now` restart handling during agent-owned reloads.
  * Restart requests are now handed off cleanly when a reload is already in progress.
  * If no reload handoff is available, the command checks restart eligibility and exits with a failure status instead of proceeding.
  * Added coverage for restart lock handoffs and eligibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->