### PR TITLE
fix(infra): preserve JSONL transcripts outside vendor cleanup roots

### DIFF
--- a/docs/TRANSCRIPT-PRESERVATION.md
+++ b/docs/TRANSCRIPT-PRESERVATION.md
@@ -1,0 +1,92 @@
+# Permanent JSONL preservation
+
+Claude Code deletes old local transcripts at startup. Its default
+`cleanupPeriodDays` is 30; zero is invalid and older versions interpreted zero
+as disabling transcript persistence. Overdeck's conversation metadata can
+outlive the JSONL, leaving a title and cost totals without readable history.
+
+`scripts/preserve-transcripts.py` provides a Linux host safeguard independent
+of dashboard deployment and Claude's lifecycle:
+
+1. Set `cleanupPeriodDays` to 365000 (1,000 years) in native Claude user
+   settings, the canonical Overdeck Claude settings, and existing private
+   Claude settings below the agents directory. Future managed launch homes
+   inherit the canonical setting. Exact original settings are backed up before
+   each change; invalid JSON causes a visible failure instead of replacement.
+   A settings failure still allows the independent transcript backup to run.
+2. Back up native Claude project JSONL, native Codex current and archived
+   session JSONL, and all JSONL beneath Overdeck's agents directory and
+   canonical Claude projects directory. This includes nested subagent files.
+3. Keep every Restic snapshot indefinitely. The service never invokes
+   snapshot expiry or repository pruning. Source removal or truncation does
+   not modify older snapshots. Restic deduplicates unchanged data.
+
+Snapshots live in `~/.overdeck/transcript-preservation/repository`, outside
+the vendor cleanup roots. The repository password is in the sibling `password`
+file with mode 0600. Preserve both when moving or backing up this machine.
+Settings originals and their source paths live in `settings-backups/`.
+
+## Install on a Linux host
+
+Requires Python 3, Restic 0.16 or newer, and a user systemd manager. From the
+Overdeck source checkout, install the reviewed script and units:
+
+```bash
+install -d -m 700 ~/.overdeck/bin ~/.config/systemd/user
+install -m 700 scripts/preserve-transcripts.py ~/.overdeck/bin/preserve-transcripts.py
+install -m 644 infra/systemd/overdeck-transcript-preservation.* ~/.config/systemd/user/
+python3 ~/.overdeck/bin/preserve-transcripts.py backup
+systemctl --user daemon-reload
+systemctl --user enable --now overdeck-transcript-preservation.timer
+```
+
+The timer runs at boot and every five minutes. It also reasserts long retention
+for existing Claude homes. A failed or incomplete backup fails the service;
+errors remain visible in `systemctl --user status` and the journal. The lock
+prevents concurrent writers. This is a host service, not a second Deacon.
+The packaged units use the default `~/.overdeck` location; for a custom home,
+set `--overdeck-home /absolute/path` in the service's `ExecStart`.
+
+Changing settings does not prove a running Claude process reloaded them.
+Project or enterprise policy can override user settings. The timer's snapshots
+are the independent safeguard, but new content has up to five minutes of
+backup latency while the machine and user manager are running. This local
+archive does not protect against loss of the entire disk; include the repository
+and password in the machine's external backups. Do not describe a long numeric
+retention period alone as an infinite-retention guarantee.
+
+## Inspect and recover
+
+```bash
+systemctl --user status overdeck-transcript-preservation.timer
+journalctl --user -u overdeck-transcript-preservation.service -n 30
+restic -r ~/.overdeck/transcript-preservation/repository \
+  -p ~/.overdeck/transcript-preservation/password snapshots
+restic -r ~/.overdeck/transcript-preservation/repository \
+  -p ~/.overdeck/transcript-preservation/password check
+```
+
+Select a snapshot that contains the missing transcript, then restore into a
+separate directory. Restoring does not require modifying current transcripts:
+
+```bash
+restic -r ~/.overdeck/transcript-preservation/repository \
+  -p ~/.overdeck/transcript-preservation/password restore SNAPSHOT_ID \
+  --target /tmp/recovered-transcripts --include '/absolute/original/path.jsonl'
+```
+
+Overdeck does not automatically read compressed Restic snapshots. After checking
+the recovered JSONL, put a copy at its original path if that path is still absent
+to make the existing transcript resolver find it. Never overwrite newer history.
+
+## Verification
+
+```bash
+python3 -m unittest discover -s scripts/tests -p 'test_preserve_transcripts.py' -v
+```
+
+Tests use disposable fixture homes and real Restic repositories. They verify
+restoration of original and appended content after fixture truncation/removal,
+nested agent transcripts, filenames with spaces and newlines, full repository
+integrity, preservation of unrelated settings and symlinks, and refusal to
+overwrite malformed settings.

--- a/infra/systemd/overdeck-transcript-preservation.service
+++ b/infra/systemd/overdeck-transcript-preservation.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Preserve all Claude and Overdeck JSONL transcripts
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 %h/.overdeck/bin/preserve-transcripts.py backup
+UMask=0077
+Environment=GOMAXPROCS=2
+Nice=10
+IOSchedulingClass=idle
+TimeoutStartSec=infinity

--- a/infra/systemd/overdeck-transcript-preservation.timer
+++ b/infra/systemd/overdeck-transcript-preservation.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Preserve transcript snapshots every five minutes without expiry
+
+[Timer]
+OnBootSec=1min
+OnCalendar=*:0/5
+Persistent=true
+Unit=overdeck-transcript-preservation.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/preserve-transcripts.py
+++ b/scripts/preserve-transcripts.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Preserve JSONL history with permanent Restic snapshots, without moving sources.
+
+Run `configure` once, then `backup` on a timer. No command expires snapshots.
+Python 3 and Restic >= 0.16 are required. See docs/TRANSCRIPT-PRESERVATION.md.
+"""
+
+import argparse
+import fcntl
+import hashlib
+import json
+import os
+from pathlib import Path
+import secrets
+import subprocess
+import sys
+import tempfile
+
+
+# Claude rejects zero. This prevents its normal age-based cleanup for 1,000
+# years; permanent snapshots provide preservation independent of that setting.
+RETENTION_DAYS = 365000
+SKIP_DIRS = {"node_modules", ".git", "plugins", "skills"}
+
+
+def walk_files(root):
+    def on_error(error):
+        raise error
+
+    if not root.exists():
+        return
+    for directory, dirs, files in os.walk(root, onerror=on_error):
+        dirs[:] = [name for name in dirs if name not in SKIP_DIRS]
+        for name in files:
+            path = Path(directory) / name
+            if not path.is_symlink():
+                yield path
+
+
+def atomic_write(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with tempfile.NamedTemporaryFile(dir=path.parent, delete=False) as output:
+        temporary = Path(output.name)
+        try:
+            output.write(data)
+            output.flush()
+            os.fsync(output.fileno())
+            os.replace(temporary, path)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+
+def protect_settings(path, backup_dir):
+    path = path.resolve()
+    original = path.read_bytes() if path.exists() else b"{}"
+    settings = json.loads(original)
+    if not isinstance(settings, dict):
+        raise ValueError(f"{path}: expected a JSON object; refusing to overwrite")
+    existing = settings.get("cleanupPeriodDays")
+    if isinstance(existing, int) and existing >= RETENTION_DAYS:
+        return False
+    # Preserve the exact original, including unrelated settings and credentials.
+    digest = hashlib.sha256(str(path).encode() + b"\0" + original).hexdigest()
+    backup = backup_dir / (digest + ".json")
+    if not backup.exists():
+        atomic_write(backup, original)
+        atomic_write(backup.with_suffix(".path"), (str(path) + "\n").encode())
+    settings["cleanupPeriodDays"] = RETENTION_DAYS
+    if path.exists() and path.read_bytes() != original:
+        raise RuntimeError(f"{path} changed during retention update; retry")
+    atomic_write(path, (json.dumps(settings, indent=2) + "\n").encode())
+    return True
+
+
+def configure(home, overdeck, storage):
+    settings = {home / ".claude/settings.json", overdeck / "harnesses/claude/settings.json"}
+    # Launch homes already running retain their own settings. Future managed
+    # homes inherit the canonical settings above. Never touch another harness.
+    for path in walk_files(overdeck / "agents"):
+        if path.name == "settings.json" and any("claude" in part for part in path.relative_to(overdeck / "agents").parts[:-1]):
+            settings.add(path)
+    changed = sum(protect_settings(path, storage / "settings-backups") for path in sorted(settings))
+    print(json.dumps({"settingsChecked": len(settings), "settingsChanged": changed}), flush=True)
+
+
+def restic(storage, *arguments, **kwargs):
+    # Do not inherit another backup job's repository, password, or exclusions.
+    env = {key: value for key, value in os.environ.items() if not key.startswith("RESTIC_")}
+    return subprocess.run([
+        "restic", "--repo", str(storage / "repository"),
+        "--password-file", str(storage / "password"),
+        "--cache-dir", str(storage / "cache"), *arguments,
+    ], env=env, check=True, **kwargs)
+
+
+def initialize(storage):
+    repository = storage / "repository"
+    password = storage / "password"
+    if not password.exists():
+        if repository.exists():
+            raise RuntimeError("Archive password is missing; restore it before continuing")
+        with open(password, "x", opener=lambda path, flags: os.open(path, flags, 0o600)) as output:
+            output.write(secrets.token_hex(32) + "\n")
+    if not (repository / "config").exists():
+        restic(storage, "init", "--repository-version", "2")
+
+
+def backup(home, overdeck, storage):
+    initialize(storage)
+    roots = [home / ".claude/projects", home / ".codex/sessions",
+             home / ".codex/archived_sessions", overdeck / "agents",
+             overdeck / "harnesses/claude/projects"]
+    # A raw NUL-delimited list handles spaces, newlines, and leading '#' safely.
+    with tempfile.NamedTemporaryFile(dir=storage) as inventory:
+        count = 0
+        for root in roots:
+            for path in walk_files(root):
+                if path.suffix == ".jsonl":
+                    inventory.write(os.fsencode(path) + b"\0")
+                    count += 1
+        inventory.flush()
+        if not count:
+            raise RuntimeError("No JSONL transcripts found; refusing an empty backup")
+        print(json.dumps({"transcriptsFound": count}), flush=True)
+        # Group by host and tag so added/removed source files do not prevent
+        # incremental reuse. Restic retains old snapshots after source deletion
+        # or truncation. Exit 3 (incomplete backup) remains a visible failure.
+        restic(storage, "backup", "--files-from-raw", inventory.name,
+               "--tag", "overdeck-transcripts", "--group-by", "host,tags", "--json", "--quiet")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=["configure", "backup"])
+    parser.add_argument("--home", type=Path, default=Path.home())
+    parser.add_argument("--overdeck-home", type=Path)
+    args = parser.parse_args()
+    home = args.home.resolve()
+    overdeck = (args.overdeck_home or home / ".overdeck").resolve()
+    storage = overdeck / "transcript-preservation"
+    storage.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.umask(0o077)
+    with (storage / "lock").open("a") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        settings_error = None
+        try:
+            configure(home, overdeck, storage)
+        except Exception as error:
+            if args.command == "configure":
+                raise
+            settings_error = error
+            print(f"Retention settings failed; still backing up transcripts: {error}", file=sys.stderr)
+        if args.command == "backup":
+            backup(home, overdeck, storage)
+        if settings_error:
+            raise settings_error
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_preserve_transcripts.py
+++ b/scripts/tests/test_preserve_transcripts.py
@@ -1,0 +1,113 @@
+"""Exercise real Restic backups using disposable fixture homes only."""
+
+import importlib.util
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "preserve-transcripts.py"
+SPEC = importlib.util.spec_from_file_location("preservation", SCRIPT)
+preservation = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(preservation)
+
+
+class SettingsTests(unittest.TestCase):
+    def test_preserves_unrelated_settings_and_original_bytes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            settings = root / "settings.json"
+            original = b'{"cleanupPeriodDays": 30, "env": {"EXAMPLE": "keep"}}'
+            settings.write_bytes(original)
+            self.assertTrue(preservation.protect_settings(settings, root / "backups"))
+            self.assertEqual(json.loads(settings.read_text()), {
+                "cleanupPeriodDays": 365000, "env": {"EXAMPLE": "keep"},
+            })
+            self.assertEqual(next((root / "backups").glob("*.json")).read_bytes(), original)
+            self.assertFalse(preservation.protect_settings(settings, root / "backups"))
+
+    def test_invalid_settings_are_never_overwritten(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            settings = root / "settings.json"
+            for original in (b'{broken', b'[]'):
+                settings.write_bytes(original)
+                with self.assertRaises(ValueError):
+                    preservation.protect_settings(settings, root / "backups")
+                self.assertEqual(settings.read_bytes(), original)
+
+    def test_settings_symlink_is_preserved(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "real.json"
+            target.write_text('{}')
+            link = root / "settings.json"
+            link.symlink_to(target)
+            preservation.protect_settings(link, root / "backups")
+            self.assertTrue(link.is_symlink())
+            self.assertEqual(json.loads(target.read_text())["cleanupPeriodDays"], 365000)
+
+
+@unittest.skipUnless(shutil.which("restic"), "Restic must be installed")
+class RecoveryTests(unittest.TestCase):
+    def test_original_and_appended_history_survive_source_truncation_and_removal(self):
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            storage = home / ".overdeck/transcript-preservation"
+            source = home / '.claude/projects/project space/#session\nname.jsonl'
+            source.parent.mkdir(parents=True)
+            first = b'{"message":"original"}\n'
+            second = first + b'{"message":"appended"}\n'
+            source.write_bytes(first)
+            agent = home / ".overdeck/agents/conv-fixture/sessions/agent.jsonl"
+            agent.parent.mkdir(parents=True)
+            agent.write_text('{"message":"managed"}\n')
+            private_settings = home / ".overdeck/agents/conv-fixture/claude-home/settings.json"
+            private_settings.parent.mkdir(parents=True)
+            private_settings.write_text('{"cleanupPeriodDays":1}')
+
+            def backup():
+                result = subprocess.run(["python3", str(SCRIPT), "backup", "--home", str(home)],
+                                        capture_output=True)
+                self.assertEqual(result.returncode, 0, result.stdout.decode() + result.stderr.decode())
+
+            def snapshots():
+                result = preservation.restic(storage, "snapshots", "--json", capture_output=True)
+                return json.loads(result.stdout)
+
+            def dump(snapshot):
+                return preservation.restic(storage, "dump", snapshot, str(source),
+                                           capture_output=True).stdout
+
+            backup()
+            first_id = snapshots()[-1]["id"]
+            source.write_bytes(second)
+            backup()
+            second_id = snapshots()[-1]["id"]
+            source.write_bytes(b'{}\n')
+            backup()
+            source.unlink()  # Disposable fixture: simulate vendor retention.
+            backup()
+            self.assertEqual(len(snapshots()), 4)
+            self.assertEqual(dump(first_id), first)
+            self.assertEqual(dump(second_id), second)
+            self.assertEqual(json.loads(private_settings.read_text())["cleanupPeriodDays"], 365000)
+            self.assertEqual(preservation.restic(storage, "dump", "latest", str(agent),
+                                                capture_output=True).stdout, agent.read_bytes())
+            preservation.restic(storage, "check", "--read-data", capture_output=True)
+
+            # Malformed retention settings must report failure without stopping
+            # the independent backup safeguard.
+            private_settings.write_text('{broken')
+            result = subprocess.run(["python3", str(SCRIPT), "backup", "--home", str(home)],
+                                    capture_output=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(len(snapshots()), 5)
+            self.assertEqual(private_settings.read_text(), '{broken')
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Claude Code's default 30-day transcript cleanup can leave Overdeck conversations with metadata but no history. Add a host service that sets native and managed Claude retention to 365,000 days and takes permanent Restic snapshots every five minutes outside vendor cleanup roots. Older snapshots survive source deletion and truncation; no automated expiry or pruning is installed.

The safeguard is separate from dashboard deployment. It includes exact settings backups, failure reporting, a lock against overlapping jobs, nested agent JSONL coverage, and recovery instructions. A malformed settings file does not prevent the independent backup. The service has been installed and verified on the development host; this PR packages the script, units, tests, and documentation for review. It does not change existing in-flight session-home work.

Validation: four Python tests using real Restic, including recovery after source append/truncation/removal, malformed settings, settings symlinks, unusual filenames, and full fixture repository integrity. Real host snapshots completed and a Tindra transcript restored byte for byte. Systemd units validated. Only Python/scripts/docs changed; the TypeScript application was not rebuilt.

Limits: this is local host protection with up to five minutes of backup latency. It requires Python 3, Restic >= 0.16, and installation of the user systemd units. External disk-loss protection requires backing up both the repository and its password. Overdeck does not automatically render archived Restic snapshots.
