### PR TITLE
fix: Kimi send-path session gate + Claude transcript watcher safety net (PAN-3825, PAN-3826)

### DIFF
--- a/src/dashboard/server/services/__tests__/conversation-service.test.ts
+++ b/src/dashboard/server/services/__tests__/conversation-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
 
@@ -1215,6 +1215,89 @@ describe('watchConversation', () => {
 
     releaseFirstCallback();
     await vi.waitFor(() => expect(callback).toHaveBeenCalledTimes(2));
+    handle.stop();
+  });
+});
+
+describe('watchConversation safety nets (missed fs.watch events)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockStat.mockImplementation(async () => {
+      const buf = await mockReadFile();
+      return { mtimeMs: Date.now() - 1_000, birthtimeMs: Date.now() - 1_000, size: buf.length };
+    });
+    mockOpen.mockImplementation(async () => {
+      const buffer = await mockReadFile();
+      return {
+        read: (buf: Buffer, offset: number, length: number, position: number) => {
+          const toCopy = Math.min(length, Math.max(0, buffer.length - position));
+          if (toCopy > 0) {
+            buffer.copy(buf, offset, position, position + toCopy);
+          }
+          return Promise.resolve({ bytesRead: toCopy, buffer: buf });
+        },
+        close: () => Promise.resolve(),
+      };
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const userLine = (uuid: string, text: string) => makeJsonlLine({
+    type: 'user',
+    uuid,
+    timestamp: '2024-01-01T00:00:00.000Z',
+    message: { content: [{ type: 'text', text }] },
+  });
+
+  it('re-parses an append that fs.watch never reported via the periodic size reconcile', async () => {
+    const firstLine = userLine('u-1', 'First');
+    let buffer = Buffer.from(`${firstLine}\n`);
+    mockReadFile.mockImplementation(async () => buffer);
+    // fs.watch stays open but never yields an event.
+    mockWatch.mockImplementationOnce(() => ({ [Symbol.asyncIterator]: () => ({ next: () => new Promise(() => {}) }) }));
+
+    const callback = vi.fn(async () => {});
+    const { watchConversation, RECONCILE_INTERVAL_MS } = await import('../conversation-service.js');
+    const handle = watchConversation('/fake/session.jsonl', callback, {
+      byteOffset: buffer.length,
+      priorState: { pendingToolUse: new Map(), unresolvedResults: new Map(), lastSequence: 0 },
+    });
+
+    await vi.advanceTimersByTimeAsync(RECONCILE_INTERVAL_MS + 10);
+    expect(callback).not.toHaveBeenCalled();
+
+    buffer = Buffer.from(`${firstLine}\n${userLine('u-2', 'Second')}\n`);
+    await vi.advanceTimersByTimeAsync(RECONCILE_INTERVAL_MS + 10);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0]![0].messages.map((m: { id: string }) => m.id)).toEqual(['u-2']);
+
+    handle.stop();
+  });
+
+  it('falls back to polling when the fs.watch iterator ends without throwing', async () => {
+    const firstLine = userLine('u-1', 'First');
+    let buffer = Buffer.from(`${firstLine}\n`);
+    mockReadFile.mockImplementation(async () => buffer);
+    mockWatch.mockImplementationOnce(() => ({
+      [Symbol.asyncIterator]: async function* () { /* closes immediately */ },
+    }));
+
+    const callback = vi.fn(async () => {});
+    const { watchConversation } = await import('../conversation-service.js');
+    const handle = watchConversation('/fake/session.jsonl', callback, {
+      byteOffset: buffer.length,
+      priorState: { pendingToolUse: new Map(), unresolvedResults: new Map(), lastSequence: 0 },
+    });
+
+    buffer = Buffer.from(`${firstLine}\n${userLine('u-2', 'Second')}\n`);
+    await vi.advanceTimersByTimeAsync(600);
+    expect(callback).toHaveBeenCalledTimes(1);
+    expect(callback.mock.calls[0]![0].messages.map((m: { id: string }) => m.id)).toEqual(['u-2']);
+
     handle.stop();
   });
 });

--- a/src/dashboard/server/services/conversation-service.ts
+++ b/src/dashboard/server/services/conversation-service.ts
@@ -9,5 +9,5 @@ export { contextUsageFromParseResult, computeContextUsage } from './conversation
 export { findLastCompactBoundary } from './conversation/compact-boundary.js';
 export { parseConversationMessages, parseEntireConversation, parseFromLastCompactBoundary } from './conversation/parser.js';
 export { snapshotSessionFiles, discoverSessionFile } from './conversation/session-files.js';
-export { gateSnapshotEmission, watchConversation } from './conversation/watch.js';
+export { gateSnapshotEmission, RECONCILE_INTERVAL_MS, watchConversation } from './conversation/watch.js';
 export type { ConversationWatchHandle } from './conversation/watch.js';

--- a/src/dashboard/server/services/conversation/watch.ts
+++ b/src/dashboard/server/services/conversation/watch.ts
@@ -1,4 +1,4 @@
-import { watch } from 'node:fs/promises';
+import { stat, watch } from 'node:fs/promises';
 import { parseConversationMessages } from './parser.js';
 import type { ParseResult, ParseState } from './types.js';
 
@@ -22,6 +22,9 @@ export function gateSnapshotEmission(
 
 // ─── File watcher ─────────────────────────────────────────────────────────────
 
+/** How often the fs.watch path re-checks the file size against the parsed offset. */
+export const RECONCILE_INTERVAL_MS = 5_000;
+
 export interface ConversationWatchHandle {
   stop: () => void;
 }
@@ -41,11 +44,20 @@ export function watchConversation(
   let priorState: ParseState | undefined = options.priorState;
   let stopped = false;
   let isParsing = false;
+  // A change that arrived mid-parse. Without this flag the append it signalled
+  // was silently dropped until the next event — which, for the last line of a
+  // turn, never comes.
+  let changePending = false;
   let abortController: AbortController | null = null;
   let pollInterval: ReturnType<typeof setTimeout> | null = null;
+  let reconcileTimer: ReturnType<typeof setTimeout> | null = null;
 
   async function handleChange(): Promise<void> {
-    if (stopped || isParsing) return;
+    if (stopped) return;
+    if (isParsing) {
+      changePending = true;
+      return;
+    }
     isParsing = true;
     try {
       const result = await parseConversationMessages(sessionFile, byteOffset, priorState);
@@ -99,6 +111,10 @@ export function watchConversation(
     } finally {
       isParsing = false;
     }
+    if (changePending && !stopped) {
+      changePending = false;
+      await handleChange();
+    }
   }
 
   // Try fs.watch first (inotify on Linux)
@@ -113,10 +129,39 @@ export function watchConversation(
         await handleChange();
       }
     } catch (err) {
-      if (!stopped) {
-        // Fallback to polling on watch failure
-        startPolling();
+      // Fall through to the polling fallback below.
+    }
+    // The iterator can also end without throwing (watcher closed by the
+    // runtime, inode replaced). Either way the subscription is still open, so
+    // never leave it with no change source at all.
+    if (!stopped) {
+      stopReconcile();
+      startPolling();
+    }
+  }
+
+  // Safety net for the fs.watch path: inotify can miss or coalesce events
+  // (and the subscription has no other way to learn the file grew), which
+  // left the reader frozen until a page refresh re-subscribed. Compare the
+  // on-disk size with what we have parsed and re-parse on any difference.
+  function startReconcile(): void {
+    async function reconcile(): Promise<void> {
+      if (stopped) return;
+      try {
+        const info = await stat(sessionFile);
+        if (info.size !== byteOffset) await handleChange();
+      } catch {
+        // Missing or unreadable file — the next tick retries.
       }
+      if (!stopped && reconcileTimer !== null) reconcileTimer = setTimeout(reconcile, RECONCILE_INTERVAL_MS);
+    }
+    reconcileTimer = setTimeout(reconcile, RECONCILE_INTERVAL_MS);
+  }
+
+  function stopReconcile(): void {
+    if (reconcileTimer !== null) {
+      clearTimeout(reconcileTimer);
+      reconcileTimer = null;
     }
   }
 
@@ -131,6 +176,7 @@ export function watchConversation(
 
   // Start watch; polling is only a fallback when fs.watch itself fails.
   startWatch();
+  startReconcile();
 
   return {
     stop() {
@@ -143,6 +189,7 @@ export function watchConversation(
         clearTimeout(pollInterval);
         pollInterval = null;
       }
+      stopReconcile();
     },
   };
 }

--- a/src/lib/composer-commands/__tests__/harness-matrix.test.ts
+++ b/src/lib/composer-commands/__tests__/harness-matrix.test.ts
@@ -46,6 +46,9 @@ vi.mock('../../runtimes/behavior.js', () => ({
     transcriptKind: 'claude-jsonl',
   })),
 }));
+vi.mock('../../runtimes/kimi-context-envelope.js', () => ({
+  waitForManagedKimiSessionId: vi.fn(async () => 'session-matrix'),
+}));
 vi.mock('../../transcript-landing.js', () => ({
   captureTranscriptUserRecordSnapshot: vi.fn(),
 }));
@@ -204,7 +207,7 @@ describe('composer command harness interception matrix (all KNOWN_HARNESSES)', (
           message,
           'conversation-message',
           'auto',
-          ...(harness === 'kimi-code' ? [{ kimiContext: { workspace: `/tmp/matrix-${harness}` } }] : []),
+          ...(harness === 'kimi-code' ? [{ kimiContext: { workspace: `/tmp/matrix-${harness}`, sessionId: 'session-matrix' } }] : []),
         );
         expect(mocks.deliverControl).not.toHaveBeenCalled();
       }

--- a/src/lib/overdeck/conversation-message.ts
+++ b/src/lib/overdeck/conversation-message.ts
@@ -10,6 +10,7 @@ import { compactConversationNative, shouldInterceptManualCompact } from '../../d
 import { watchForEatenConversationMessage } from '../../dashboard/server/services/conversation-eaten-message-watcher.js';
 import { modelSupportsImagesSync } from '../model-capabilities.js';
 import { getHarnessBehavior } from '../runtimes/behavior.js';
+import { waitForManagedKimiSessionId } from '../runtimes/kimi-context-envelope.js';
 import type { RuntimeName } from '../runtimes/types.js';
 import { captureTranscriptUserRecordSnapshot } from '../transcript-landing.js';
 import { deliverAgentMessage, injectPiConversationMemory } from '../agents.js';
@@ -533,12 +534,24 @@ export async function handleConversationMessage(
     try {
       const method = resolveConversationDeliveryMethod(conv);
       if (harness === 'kimi-code') {
+        // The composer enables the moment the tmux session exists, but the
+        // spawn path may still be diffing Kimi's session bucket to capture the
+        // session id (up to 60s). Wait for the pointer file — bounded under the
+        // frontend's 20s request timeout — instead of failing the first
+        // message with "captured kimi-session-id is missing".
+        const kimiSessionId = await waitForManagedKimiSessionId(conv.tmuxSession);
+        if (!kimiSessionId) {
+          return jsonResponse(
+            { error: 'Kimi session is still starting (no captured kimi-session-id yet). Wait a moment and send again.' },
+            { status: 503 },
+          );
+        }
         await deliverAgentMessage(
           conv.tmuxSession,
           deliveredMessage,
           'conversation-message',
           method,
-          { kimiContext: { workspace: conv.cwd } },
+          { kimiContext: { workspace: conv.cwd, sessionId: kimiSessionId } },
         );
       } else {
         await deliverAgentMessage(conv.tmuxSession, deliveredMessage, 'conversation-message', method);

--- a/src/lib/runtimes/__tests__/kimi-context-envelope.test.ts
+++ b/src/lib/runtimes/__tests__/kimi-context-envelope.test.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   KIMI_CONTEXT_END,
@@ -11,6 +11,7 @@ import {
   KIMI_TASK_START,
   markKimiContextDelivered,
   prepareKimiMessage,
+  waitForManagedKimiSessionId,
 } from '../kimi-context-envelope.js';
 
 describe('native Kimi managed-context envelope', () => {
@@ -73,5 +74,33 @@ describe('native Kimi managed-context envelope', () => {
     await expect(prepareKimiMessage('agent-no-session', '/workspace/project', 'Task', {
       contextFiles: [contextFile],
     })).rejects.toThrow(/captured kimi-session-id is missing/);
+  });
+
+  describe('waitForManagedKimiSessionId', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('resolves once the spawn path writes the pointer file', async () => {
+      const agentId = 'conv-kimi-wait';
+      const pending = waitForManagedKimiSessionId(agentId, { timeoutMs: 5_000, pollMs: 250, overdeckHome });
+
+      await vi.advanceTimersByTimeAsync(600);
+      mkdirSync(join(overdeckHome, 'agents', agentId), { recursive: true });
+      writeFileSync(join(overdeckHome, 'agents', agentId, 'kimi-session-id'), 'session-late\n');
+      await vi.advanceTimersByTimeAsync(300);
+
+      await expect(pending).resolves.toBe('session-late');
+    });
+
+    it('returns null at the deadline when the id never appears', async () => {
+      const pending = waitForManagedKimiSessionId('conv-kimi-never', { timeoutMs: 1_000, pollMs: 250, overdeckHome });
+      await vi.advanceTimersByTimeAsync(1_100);
+      await expect(pending).resolves.toBeNull();
+    });
   });
 });

--- a/src/lib/runtimes/kimi-context-envelope.ts
+++ b/src/lib/runtimes/kimi-context-envelope.ts
@@ -45,6 +45,32 @@ export function readManagedKimiSessionId(agentId: string, overdeckHome = getOver
   }
 }
 
+/**
+ * Wait for the spawn path to persist the captured kimi-session-id.
+ *
+ * A conversation's tmux session exists (and the composer enables) before
+ * `spawnConversationSession` finishes diffing Kimi's session bucket, so a
+ * message sent in that window used to fail with "captured kimi-session-id is
+ * missing". Poll the pointer file instead of failing on the first miss. Returns
+ * null when the id has still not appeared at the deadline — the caller decides
+ * how to report that (the spawn may have failed, or Kimi may still be starting).
+ */
+export async function waitForManagedKimiSessionId(
+  agentId: string,
+  options: { timeoutMs?: number; pollMs?: number; overdeckHome?: string } = {},
+): Promise<string | null> {
+  const timeoutMs = options.timeoutMs ?? 15_000;
+  const pollMs = options.pollMs ?? 250;
+  const overdeckHome = options.overdeckHome ?? getOverdeckHome();
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const sessionId = readManagedKimiSessionId(agentId, overdeckHome);
+    if (sessionId) return sessionId;
+    if (Date.now() >= deadline) return null;
+    await new Promise<void>((resolve) => setTimeout(resolve, Math.min(pollMs, Math.max(0, deadline - Date.now()))));
+  }
+}
+
 /** Pure formatter: context first, original task afterward, with hard delimiters. */
 export function buildKimiContextEnvelope(contextFiles: readonly string[], taskMessage: string): {
   message: string;


### PR DESCRIPTION
Fixes #3825 and #3826. Two independent commits, both against `origin/main` (0.50.3).

**Kimi conversations (#3825):** the send path now waits for the captured `kimi-session-id` pointer (bounded at 15s, under the frontend's 20s request timeout) instead of failing the first message with "captured kimi-session-id is missing", passes the id explicitly, and returns a 503 "still starting" if it never appears.

**Conversation view freezing until refresh (#3826):** the Claude JSONL watcher gains a 5s size-vs-offset reconcile, a dirty flag for changes arriving mid-parse, and a polling fallback when the fs.watch iterator ends cleanly. The HTTP poll is disabled while streaming, so this watcher was the only change source.

Verified locally: targeted vitest files (kimi-context-envelope, conversation-service watcher, harness-matrix, delivery, resume-contract-delivery) pass; `npm run typecheck` and `npm run lint` pass. Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK81q98h1a1HMEbdDafFwC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conversation monitoring so updates are detected reliably, including changes made during processing and missed file-system notifications.
  - Added a fallback polling mechanism when file monitoring stops unexpectedly.
  - Improved Kimi Code message delivery by waiting for the session to become available, preventing failures when the first message arrives too quickly.
  - Requests now return a temporary unavailable response when the session cannot be ready within the allowed time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->