### PR TITLE
fix(infra): pin Effect transitive deps when staging the desktop server

### DIFF
--- a/apps/desktop/scripts/prepare-server-resources.mjs
+++ b/apps/desktop/scripts/prepare-server-resources.mjs
@@ -124,6 +124,32 @@ const pinnedDependencies = (packages, label) => {
   return dependencies;
 };
 
+// Transitive pins for the fresh `npm install` below. The stubs pin only the
+// externals the bundle imports directly; npm then resolves THEIR dependencies
+// from the registry by semver range, and a prerelease family like
+// @effect/* (`^4.0.0-beta.73` also admits `4.0.0-rc.*`) can drift onto a
+// version whose peers do not exist yet. On 2026-09-11 that broke every
+// desktop build (`@effect/platform-node-shared@4.0.0-rc.114` requiring
+// `effect@^4.0.0-rc.114`). Pin every Effect package to what the repo root
+// actually runs, via npm `overrides`, so the packaged server matches `pan up`.
+const rootInstalledOverrides = () => {
+  const overrides = {};
+  const pin = (packageName) => {
+    const manifestPath = join(repoRoot, "node_modules", packageName, "package.json");
+    if (existsSync(manifestPath)) {
+      overrides[packageName] = JSON.parse(readFileSync(manifestPath, "utf8")).version;
+    }
+  };
+  pin("effect");
+  const scopeDir = join(repoRoot, "node_modules", "@effect");
+  if (existsSync(scopeDir)) {
+    for (const entry of readdirSync(scopeDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      if (entry.isDirectory() || entry.isSymbolicLink()) pin(`@effect/${entry.name}`);
+    }
+  }
+  return overrides;
+};
+
 const installDependencies = (runtimeDir) => {
   execSync("npm install --omit=dev --no-audit --no-fund", {
     cwd: runtimeDir,
@@ -294,6 +320,7 @@ writeFileSync(
       private: true,
       type: "module",
       dependencies,
+      overrides: rootInstalledOverrides(),
     },
     null,
     2,
@@ -375,6 +402,7 @@ writeFileSync(
       private: true,
       type: "module",
       dependencies: cliDependencies,
+      overrides: rootInstalledOverrides(),
     },
     null,
     2,


### PR DESCRIPTION
All three v0.50.4 desktop builds and the "Publish desktop to npm" step failed (run 34573081787) with:

```
npm error notarget No matching version found for effect@^4.0.0-rc.114.
```

Root cause is registry drift, not our diff: `@effect/platform-node@4.0.0-beta.73` depends on `@effect/platform-node-shared@^4.0.0-beta.73`, which now resolves to `4.0.0-rc.114` on a fresh `npm install`, and that version's peer `effect@^4.0.0-rc.114` does not exist yet. Our lockfile pins beta.73 so `pan up` is unaffected; only the desktop prepare script's from-registry install breaks.

Fix: the generated server and CLI stubs now carry npm `overrides` pinning `effect` and every `@effect/*` package to the root-installed version.

Verified locally with a minimal stub: the same install fails with ETARGET without the overrides and succeeds with them (resolves platform-node-shared 4.0.0-beta.73).

`@overdeck/core@0.50.4` and `@overdeck/contracts@0.50.4` are already on npm; `@overdeck/desktop` and the GitHub Release need a follow-up tag after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LK81q98h1a1HMEbdDafFwC
